### PR TITLE
Survey flyers zip code should only be required if the promo materials box is checked.

### DIFF
--- a/brambling/forms/orders.py
+++ b/brambling/forms/orders.py
@@ -141,7 +141,7 @@ class AttendeeHousingDataForm(MemoModelForm):
 
 
 class SurveyDataForm(forms.ModelForm):
-    send_flyers_zip = USZipCodeField(widget=forms.TextInput)
+    send_flyers_zip = USZipCodeField(widget=forms.TextInput, required=False)
 
     class Meta:
         model = Order
@@ -162,6 +162,7 @@ class SurveyDataForm(forms.ModelForm):
             self.fields['send_flyers_city'].required = True
             self.fields['send_flyers_state_or_province'].required = True
             self.fields['send_flyers_country'].required = True
+            self.fields['send_flyers_zip'].required = True
         return send_flyers
 
 


### PR DESCRIPTION
Currently you'll always get stuck on the survey page unless you fill in the zip code, which is... weird.
