### PR TITLE
Updated event summary to include refund finances and differentiate between pending and completed payments.

### DIFF
--- a/brambling/templates/brambling/event/organizer/summary.html
+++ b/brambling/templates/brambling/event/organizer/summary.html
@@ -20,20 +20,24 @@
 				</div>
 				<ul class='list-group'>
 					<li class='list-group-item'>
-						Gross sales
-						<strong class='pull-right text-info'>{{ gross_sales|format_money:event.currency }}</strong>
+						Payments received
+						<strong class='pull-right text-info'>{{ confirmed_payments|format_money:event.currency }}</strong>
+					</li>
+					<li class='list-group-item'>
+						Payments pending
+						<strong class='pull-right text-info'>{{ pending_payments|format_money:event.currency }}</strong>
 					</li>
 					<li class='list-group-item'>
 						Discounts
 						<strong class='pull-right text-danger'>{{ total_discounts|format_money:event.currency }}</strong>
 					</li>
 					<li class='list-group-item'>
-						Payments outstanding
-						<strong class='pull-right{% if payments_outstanding %} text-danger{% endif %}'>{{ payments_outstanding|format_money:event.currency }}</strong>
+						Refunds
+						<strong class='pull-right text-danger'>{{ total_refunds|format_money:event.currency }}</strong>
 					</li>
-					<li class='list-group-item list-group-item-success'>
+					<li class='list-group-item {% if net_pending > 0 %}list-group-item-success{% endif %}{% if net_pending < 0 %}list-group-item-danger{% endif %}'>
 						<strong>Net total</strong>
-						<strong class='pull-right text-success'>{{ payments_received|format_money:event.currency }}</strong>
+						<strong class='pull-right {% if net_pending > 0 %}text-success{% endif %}{% if net_pending < 0 %}text-danger{% endif %}'>{{ net_pending|format_money:event.currency }}</strong>
 					</li>
 				</ul>
 			</div>

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -83,17 +83,24 @@ class EventSummaryView(TemplateView):
         return super(EventSummaryView, self).get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
+        # For the summary, we only display completed order information.
+        # We can show detailed information on a more detailed finances
+        # page.
         context = super(EventSummaryView, self).get_context_data(**kwargs)
 
         itemoptions = ItemOption.objects.filter(
             item__event=self.event
-        ).select_related('item').annotate(Count('boughtitem'))
+        ).select_related('item')
 
         gross_sales = 0
         itemoption_map = {}
 
         for itemoption in itemoptions:
             itemoption_map[itemoption.pk] = itemoption
+            itemoption.boughtitem__count = BoughtItem.objects.filter(
+                item_option=itemoption,
+                order__status__in=(Order.PENDING, Order.COMPLETED)
+            ).count()
             gross_sales += itemoption.price * itemoption.boughtitem__count
 
         discounts = list(Discount.objects.filter(
@@ -112,7 +119,19 @@ class EventSummaryView(TemplateView):
             total_discounts += discount.savings()
         total_discounts = min(total_discounts, gross_sales)
 
-        total_payments = Payment.objects.filter(order__event=self.event).aggregate(sum=Sum('amount'))['sum'] or 0
+        total_refunds = Refund.objects.filter(
+            order__event=self.event,
+        ).aggregate(sum=Sum('amount'))['sum'] or 0
+
+        confirmed_payments = Payment.objects.filter(
+            order__event=self.event,
+            is_confirmed=True,
+        ).aggregate(sum=Sum('amount'))['sum'] or 0
+
+        pending_payments = Payment.objects.filter(
+            order__event=self.event,
+            is_confirmed=False,
+        ).aggregate(sum=Sum('amount'))['sum'] or 0
 
         context.update({
             'event': self.event,
@@ -122,10 +141,13 @@ class EventSummaryView(TemplateView):
             'itemoptions': itemoptions,
             'discounts': discounts,
 
-            'gross_sales': gross_sales,
+            'confirmed_payments': confirmed_payments,
+            'pending_payments': pending_payments,
             'total_discounts': total_discounts,
-            'payments_received': total_payments,
-            'payments_outstanding': gross_sales - total_discounts - total_payments
+            'total_refunds': total_refunds,
+
+            'net_confirmed': confirmed_payments - total_discounts - total_refunds,
+            'net_pending': confirmed_payments + pending_payments - total_discounts - total_refunds,
         })
 
         if self.event.collect_housing_data:


### PR DESCRIPTION
@nmorduch I think this resolves the event summary page display for now - did you want to include the order summary improvements as part of this ticket / include changes there? The data should now all be available. If there's anything missing let me know.