### PR TITLE
Checkout relayout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    autoprefixer-rails (5.1.7)
+    autoprefixer-rails (5.1.7.1)
       execjs
       json
-    bootstrap-sass (3.3.3)
+    bootstrap-sass (3.3.4)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
     chunky_png (1.3.4)

--- a/brambling/static/brambling/css/styles.css
+++ b/brambling/static/brambling/css/styles.css
@@ -424,6 +424,10 @@ hr {
   clip: auto;
 }
 
+[role="button"] {
+  cursor: pointer;
+}
+
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: "St Ryde", Georgia, "Times New Roman", Times, serif;
@@ -561,7 +565,7 @@ mark,
   text-transform: lowercase;
 }
 
-.text-uppercase {
+.text-uppercase, .initialism {
   text-transform: uppercase;
 }
 
@@ -739,7 +743,6 @@ abbr[data-original-title] {
 
 .initialism {
   font-size: 90%;
-  text-transform: uppercase;
 }
 
 blockquote {
@@ -2035,9 +2038,11 @@ output {
   color: #999;
 }
 .form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
-  cursor: not-allowed;
   background-color: #eeeeee;
   opacity: 1;
+}
+.form-control[disabled], fieldset[disabled] .form-control {
+  cursor: not-allowed;
 }
 
 textarea.form-control {
@@ -2132,6 +2137,7 @@ input[type="search"] {
 
 .radio-inline,
 .checkbox-inline {
+  position: relative;
   display: inline-block;
   padding-left: 20px;
   margin-bottom: 0;
@@ -2169,6 +2175,7 @@ input[type="checkbox"] {
   padding-top: 7px;
   padding-bottom: 7px;
   margin-bottom: 0;
+  min-height: 34px;
 }
 .form-control-static.input-lg, .input-group-lg > .form-control-static.form-control,
 .input-group-lg > .form-control-static.input-group-addon,
@@ -2226,6 +2233,7 @@ select[multiple].input-sm,
   padding: 5px 10px;
   font-size: 12px;
   line-height: 1.5;
+  min-height: 32px;
 }
 
 .input-lg, .input-group-lg > .form-control,
@@ -2275,6 +2283,7 @@ select[multiple].input-lg,
   padding: 10px 16px;
   font-size: 18px;
   line-height: 1.3333333;
+  min-height: 38px;
 }
 
 .has-feedback {
@@ -2750,11 +2759,9 @@ input[type="button"].btn-block {
 
 .collapse {
   display: none;
-  visibility: hidden;
 }
 .collapse.in {
   display: block;
-  visibility: visible;
 }
 
 tr.collapse.in {
@@ -2783,7 +2790,7 @@ tbody.collapse.in {
   height: 0;
   margin-left: 2px;
   vertical-align: middle;
-  border-top: 4px solid;
+  border-top: 4px dashed;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
 }
@@ -3395,11 +3402,9 @@ tbody.collapse.in {
 
 .tab-content > .tab-pane {
   display: none;
-  visibility: hidden;
 }
 .tab-content > .active {
   display: block;
-  visibility: visible;
 }
 
 .nav-tabs .dropdown-menu {
@@ -3466,7 +3471,6 @@ tbody.collapse.in {
   }
   .navbar-collapse.collapse {
     display: block !important;
-    visibility: visible !important;
     height: auto !important;
     padding-bottom: 0;
     overflow: visible !important;
@@ -4097,7 +4101,7 @@ tbody.collapse.in {
   position: relative;
   top: -1px;
 }
-.btn-xs .badge, .btn-group-xs > .btn .badge {
+.btn-xs .badge, .btn-group-xs > .btn .badge, .btn-group-xs > .btn .badge {
   top: 0;
   padding: 1px 5px;
 }
@@ -4923,10 +4927,12 @@ a.list-group-item-danger.active, a.list-group-item-danger.active:hover, a.list-g
   width: 100%;
   border: 0;
 }
-.embed-responsive.embed-responsive-16by9 {
+
+.embed-responsive-16by9 {
   padding-bottom: 56.25%;
 }
-.embed-responsive.embed-responsive-4by3 {
+
+.embed-responsive-4by3 {
   padding-bottom: 75%;
 }
 
@@ -4993,7 +4999,7 @@ button.close {
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 1040;
+  z-index: 1050;
   -webkit-overflow-scrolling: touch;
   outline: 0;
 }
@@ -5038,10 +5044,12 @@ button.close {
 }
 
 .modal-backdrop {
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
+  bottom: 0;
   left: 0;
+  z-index: 1040;
   background-color: #000;
 }
 .modal-backdrop.fade {
@@ -5128,7 +5136,6 @@ button.close {
   position: absolute;
   z-index: 1070;
   display: block;
-  visibility: visible;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 12px;
   font-weight: normal;
@@ -5631,7 +5638,6 @@ button.close {
 
 .hidden {
   display: none !important;
-  visibility: hidden !important;
 }
 
 .affix {

--- a/brambling/templates/brambling/event/order/__base.html
+++ b/brambling/templates/brambling/event/order/__base.html
@@ -114,5 +114,33 @@
 	{% endif %}
 
 	{{ block.super }}
+
 	<script type="text/javascript" src="{% static "zenaida/js/bootstrap/modal.js" %}"></script>
+
+	{# Make the shopping cart remove button ajaxy. #}
+	<script type="text/javascript">
+		{# TODO: Rewrite this javascript not to use the `target` attribute. Probably to submit forms. #}
+		$(function(){
+			$('a[target]').on('click', function(e){
+				var $this = $(this);
+				if ($this.attr('target') === '_blank') return true;
+				$.post($this.attr('target'), function(data){
+					if (data.success) {
+						// if it's a remove button, don't reload, just remove the item
+						if ($this.is('[target*="remove"]')){
+							$this.closest('li, tr').remove();
+						// otherwise, just refresh for now
+						} else {
+							document.location.reload()
+						}
+					} else if (data.error) {
+						$('.stepbar').after(
+							"<div class='alert alert-dismissable alert-danger'><button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;</button> " + data.error + "</div>"
+						);
+					}
+				});
+				e.preventDefault();
+			})
+		});
+	</script>
 {% endblock %}

--- a/brambling/templates/brambling/event/order/__base.html
+++ b/brambling/templates/brambling/event/order/__base.html
@@ -92,9 +92,11 @@
 
 {% block after %}
 	<div class="row">
-		<div class="col-sm-4 col-sm-offset-8">
+		<div class="col-md-5 col-md-offset-7">
 			{% block next_step_button %}
-				{% include "brambling/event/order/_next_step_button.html" %}
+				{% if next_step %}
+					{% include "brambling/event/order/_next_step_button.html" %}
+				{% endif %}
 			{% endblock %}
 		</div>
 {% endblock %}

--- a/brambling/templates/brambling/event/order/__base.html
+++ b/brambling/templates/brambling/event/order/__base.html
@@ -94,7 +94,7 @@
 	<div class="row">
 		<div class="col-md-5 col-md-offset-7">
 			{% block next_step_button %}
-				{% if next_step %}
+				{% if next_step and next_step.is_accessible %}
 					{% include "brambling/event/order/_next_step_button.html" %}
 				{% endif %}
 			{% endblock %}

--- a/brambling/templates/brambling/event/order/__base.html
+++ b/brambling/templates/brambling/event/order/__base.html
@@ -69,11 +69,13 @@
 															<tr>
 																<td>{{ personitem.item_option.item.name }} ({{ personitem.item_option.name }})</td>
 																<td>{{ personitem.item_option.price|format_money:event.currency }}</td>
-																<td><a target='{% if code_in_url %}{% url "brambling_event_shop_remove" event_slug=event.slug pk=personitem.pk code=order.code %}{% else %}{% url "brambling_event_shop_remove" event_slug=event.slug pk=personitem.pk %}{% endif %}' href='javascript://' class='text-danger pull-right'><span class='fa fa-times'></span></a></td>
 															</tr>
 														{% endfor %}
 													{% endfor %}
 												</table>
+												<div class="modal-footer">
+													To add or remove items in your cart, return to the <a href="{% url 'brambling_event_shop' event_slug=event.slug %}">event shop</a>.
+												</div>
 											</div>
 										</div>
 									</div>
@@ -126,13 +128,8 @@
 				if ($this.attr('target') === '_blank') return true;
 				$.post($this.attr('target'), function(data){
 					if (data.success) {
-						// if it's a remove button, don't reload, just remove the item
-						if ($this.is('[target*="remove"]')){
-							$this.closest('li, tr').remove();
-						// otherwise, just refresh for now
-						} else {
-							document.location.reload()
-						}
+						// just refresh for now
+						document.location.reload()
 					} else if (data.error) {
 						$('.stepbar').after(
 							"<div class='alert alert-dismissable alert-danger'><button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;</button> " + data.error + "</div>"

--- a/brambling/templates/brambling/event/order/__base.html
+++ b/brambling/templates/brambling/event/order/__base.html
@@ -1,6 +1,6 @@
 {% extends 'brambling/layouts/12.html' %}
 
-{% load staticfiles %}
+{% load staticfiles zenaida %}
 
 {% block title %}{{ event.name }} – {{ block.super }}{% endblock %}
 
@@ -47,8 +47,39 @@
 						{% include "brambling/event/order/_expiry_countdown.html" with expiry_time=order.cart_expire_time %}
 					</div>
 					<div class='col-md-6'>
-						{% block next_step_button %}
-							{% include "brambling/event/order/_next_step_button.html" %}
+						{% block cart %}
+							{% if order.has_cart %}
+								{% with order.get_groupable_cart as cart %}
+									<a href="#cartModal" class="btn btn-lg btn-block btn-default" data-toggle="modal" data-target="#cartModal">
+										<i class="fa fa-fw fa-shopping-cart"></i> Cart ({{ cart.count }} item{{ cart|pluralize }})
+									</a>
+
+									{# TODO: this modal needs to be way more attractive. Also it'd be nice if it were a popover instead of a modal on desktop. #}
+									{% regroup order.get_groupable_cart by item_option.item as cart_list %}
+									<div class="modal fade" id="cartModal">
+										<div class="modal-dialog">
+											<div class="modal-content">
+												<div class="modal-header">
+													<a href="#" class="pull-right" data-dismiss="modal"><i class="fa fa-times"></i></a>
+													<h4 class="modal-title">Cart ({{ cart.count }} item{{ cart|pluralize }})</h4>
+												</div>
+												<table class="table">
+													{% for options in cart_list %}
+														{% for personitem in options.list %}
+															<tr>
+																<td>{{ personitem.item_option.item.name }} ({{ personitem.item_option.name }})</td>
+																<td>{{ personitem.item_option.price|format_money:event.currency }}</td>
+																<td><a target='{% if code_in_url %}{% url "brambling_event_shop_remove" event_slug=event.slug pk=personitem.pk code=order.code %}{% else %}{% url "brambling_event_shop_remove" event_slug=event.slug pk=personitem.pk %}{% endif %}' href='javascript://' class='text-danger pull-right'><span class='fa fa-times'></span></a></td>
+															</tr>
+														{% endfor %}
+													{% endfor %}
+												</table>
+											</div>
+										</div>
+									</div>
+
+								{% endwith %}
+							{% endif %}
 						{% endblock %}
 					</div>
 				</div>
@@ -57,6 +88,15 @@
 			{% endif %}
 		{% endif %}
 	{% endblock countdown_next %}
+{% endblock %}
+
+{% block after %}
+	<div class="row">
+		<div class="col-sm-4 col-sm-offset-8">
+			{% block next_step_button %}
+				{% include "brambling/event/order/_next_step_button.html" %}
+			{% endblock %}
+		</div>
 {% endblock %}
 
 {% block javascripts %}

--- a/brambling/templates/brambling/event/order/__base.html
+++ b/brambling/templates/brambling/event/order/__base.html
@@ -94,7 +94,7 @@
 
 {% block after %}
 	<div class="row">
-		<div class="col-md-5 col-md-offset-7">
+		<div class="col-md-5">
 			{% block next_step_button %}
 				{% if next_step and next_step.is_accessible %}
 					{% include "brambling/event/order/_next_step_button.html" %}

--- a/brambling/templates/brambling/event/order/__base.html
+++ b/brambling/templates/brambling/event/order/__base.html
@@ -56,12 +56,12 @@
 
 									{# TODO: this modal needs to be way more attractive. Also it'd be nice if it were a popover instead of a modal on desktop. #}
 									{% regroup order.get_groupable_cart by item_option.item as cart_list %}
-									<div class="modal fade" id="cartModal">
+									<div class="modal fade" id="cartModal" tabindex="-1" role="dialog" aria-labelledby="cartTitle" aria-hidden="true">
 										<div class="modal-dialog">
 											<div class="modal-content">
 												<div class="modal-header">
-													<a href="#" class="pull-right" data-dismiss="modal"><i class="fa fa-times"></i></a>
-													<h4 class="modal-title">Cart ({{ cart.count }} item{{ cart|pluralize }})</h4>
+													<a href="#" class="pull-right" data-dismiss="modal" aria-label="Close"><i class="fa fa-times"></i></a>
+													<h4 class="modal-title" id="cartTitle">Cart ({{ cart.count }} item{{ cart|pluralize }})</h4>
 												</div>
 												<table class="table">
 													{% for options in cart_list %}

--- a/brambling/templates/brambling/event/order/_next_step_button.html
+++ b/brambling/templates/brambling/event/order/_next_step_button.html
@@ -1,1 +1,1 @@
-<a class='btn btn-success btn-block btn-lg' href='{% if code_in_url %}{% url next_step.view_name event_slug=event.slug code=order.code %}{% else %}{% url next_step.view_name event_slug=event.slug %}{% endif %}'{% if not next_step.is_accessible %} disabled{% endif %}> Next step <i class='fa fa-chevron-right'></i></a>
+<a class='btn btn-success btn-block btn-lg' href='{% if code_in_url %}{% url next_step.view_name event_slug=event.slug code=order.code %}{% else %}{% url next_step.view_name event_slug=event.slug %}{% endif %}'> Next step <i class='fa fa-chevron-right'></i></a>

--- a/brambling/templates/brambling/event/order/attendee_basic_data.html
+++ b/brambling/templates/brambling/event/order/attendee_basic_data.html
@@ -4,6 +4,10 @@
 
 {% block title %}{% if attendee.pk %}Edit {{ attendee.get_full_name }}{% else %}Add an attendee{% endif %} – {{ block.super }}{% endblock %}
 
+
+{# Don't display a next step button. The form's own button will suffice. #}
+{% block next_step_button %}{% endblock %}
+
 {% block main %}
 	{{ block.super }}
 

--- a/brambling/templates/brambling/event/order/attendee_housing.html
+++ b/brambling/templates/brambling/event/order/attendee_housing.html
@@ -30,6 +30,6 @@
 			</div>
 		{% endfor %}
 
-		<button type="submit" class="btn btn-success btn-block btn-lg">Next step <span class='fa fa-chevron-right'></span></button>
+		<button type="submit" class="btn btn-success btn-lg col-md-5 col-md-offset-7">Next step <span class='fa fa-chevron-right'></span></button>
 	</form>
 {% endblock %}

--- a/brambling/templates/brambling/event/order/attendee_housing.html
+++ b/brambling/templates/brambling/event/order/attendee_housing.html
@@ -30,6 +30,6 @@
 			</div>
 		{% endfor %}
 
-		<button type="submit" class="btn btn-success btn-lg col-md-5 col-md-offset-7">Next step <span class='fa fa-chevron-right'></span></button>
+		<button type="submit" class="btn btn-success btn-lg col-md-5">Next step <span class='fa fa-chevron-right'></span></button>
 	</form>
 {% endblock %}

--- a/brambling/templates/brambling/event/order/email.html
+++ b/brambling/templates/brambling/event/order/email.html
@@ -20,6 +20,6 @@
 			{% endform %}
 		</div>
 
-		<button type="submit" class="btn btn-success btn-block btn-lg">Next step <span class='fa fa-chevron-right'></span></button>
+		<button type="submit" class="btn btn-success btn-lg col-md-5 col-md-offset-7">Next step <span class='fa fa-chevron-right'></span></button>
 	</form>
 {% endblock %}

--- a/brambling/templates/brambling/event/order/hosting.html
+++ b/brambling/templates/brambling/event/order/hosting.html
@@ -27,79 +27,78 @@
 	</script>
 {% endblock %}
 
+{# Don't display a next step button. The form's own button will suffice. #}
+{% block next_step_button %}{% endblock %}
+
 {% block main %}
 	{{ block.super }}
 
-	<form action="" class="max-width-sm" method="post" novalidate>
-		{% csrf_token %}
+	<form action="" method="post" novalidate>
+		<div class="max-width-sm">
+			{% csrf_token %}
 
-		{% formrow form.providing_housing with label="I want to house visiting dancers" %}
+			{% formrow form.providing_housing with label="I want to house visiting dancers" %}
 
-		<div id='hostingFields' class="collapse{% if form.instance.order.providing_housing %} in{% endif %}">
-			{% form form using "brambling/forms/hosting.html" %}
+			<div id='hostingFields' class="collapse{% if form.instance.order.providing_housing %} in{% endif %}">
+				{% form form using "brambling/forms/hosting.html" %}
 
-			<div class="panel panel-default margin-leader-dbl">
-				<header class="panel-heading">
-					<h4 class="panel-title">Capacity</h4>
-				</header>
-				<div class="panel-body">
-					<p>
-						In the form below, use the <strong>Comfy</strong> column to specify
-						how many people can sleep comfortably in your home. Use the
-						<strong>Max</strong> column to specify (if different) the maximum number of people
-						you can host if they are willing to sleep in slightly tighter
-						conditions.
-					</p>
-					<table class="table table-striped table-condensed" id="HostingFormTable">
-						<thead>
-							<tr>
-								<th class="col-xs-4">Date</th>
-								<th class="col-xs-2">Comfy</th>
-								<th class="col-xs-2">Max</th>
-								<th class="col-xs-4">&nbsp;</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for form in form.slot_forms %}
-								{% form form using %}
-									<tr{% if form.errors %} class="danger"{% endif %}>
-										<td class="text-right">{{ form.instance.night }}</td>
-										<td>{% formfield form.spaces %}</td>
-										<td>{% formfield form.spaces_max %}</td>
-										<td>
-											{% if forloop.first %}
-												<button class="btn btn-default btn-block" type="button" id="FillAllButton">
-													Copy to all rows <i class="fa fa-arrow-down"></i>
-												</button>
-											{% endif %}
-										</td>
-									</tr>
-									{% if form.errors %}
-										{% for key, list in form.errors.iteritems %}
-											{% for error in list %}
-												<tr class="danger text-danger">
-													<td></td>
-													<td colspan="2">
-														{{ error}}
-													</td>
-													<td></td>
-												</tr>
+				<div class="panel panel-default margin-leader-dbl">
+					<header class="panel-heading">
+						<h4 class="panel-title">Capacity</h4>
+					</header>
+					<div class="panel-body">
+						<p>
+							In the form below, use the <strong>Comfy</strong> column to specify
+							how many people can sleep comfortably in your home. Use the
+							<strong>Max</strong> column to specify (if different) the maximum number of people
+							you can host if they are willing to sleep in slightly tighter
+							conditions.
+						</p>
+						<table class="table table-striped table-condensed" id="HostingFormTable">
+							<thead>
+								<tr>
+									<th class="col-xs-4">Date</th>
+									<th class="col-xs-2">Comfy</th>
+									<th class="col-xs-2">Max</th>
+									<th class="col-xs-4">&nbsp;</th>
+								</tr>
+							</thead>
+							<tbody>
+								{% for form in form.slot_forms %}
+									{% form form using %}
+										<tr{% if form.errors %} class="danger"{% endif %}>
+											<td class="text-right">{{ form.instance.night }}</td>
+											<td>{% formfield form.spaces %}</td>
+											<td>{% formfield form.spaces_max %}</td>
+											<td>
+												{% if forloop.first %}
+													<button class="btn btn-default btn-block" type="button" id="FillAllButton">
+														Copy to all rows <i class="fa fa-arrow-down"></i>
+													</button>
+												{% endif %}
+											</td>
+										</tr>
+										{% if form.errors %}
+											{% for key, list in form.errors.iteritems %}
+												{% for error in list %}
+													<tr class="danger text-danger">
+														<td></td>
+														<td colspan="2">
+															{{ error}}
+														</td>
+														<td></td>
+													</tr>
+												{% endfor %}
 											{% endfor %}
-										{% endfor %}
-									{% endif %}
-								{% endform %}
-							{% endfor %}
-						</tbody>
-					</table>
+										{% endif %}
+									{% endform %}
+								{% endfor %}
+							</tbody>
+						</table>
+					</div>
 				</div>
 			</div>
-		</div>
-		<button type="submit" class="btn btn-success btn-block btn-lg">Next step <span class='fa fa-chevron-right'></span></button>
+		</div>{# /.max-width-sm #}
+		<button type="submit" class="btn btn-success btn-lg col-md-5 col-md-offset-7">Next step <span class='fa fa-chevron-right'></span></button>
 	</form>
 {% endblock %}
-
-{% block countdown_next %}
-	{% if order.has_cart %}
-		{% include "brambling/event/order/_expiry_countdown.html" with expiry_time=order.cart_expire_time %}
-	{% endif %}
-{% endblock countdown_next %}

--- a/brambling/templates/brambling/event/order/hosting.html
+++ b/brambling/templates/brambling/event/order/hosting.html
@@ -99,6 +99,6 @@
 				</div>
 			</div>
 		</div>{# /.max-width-sm #}
-		<button type="submit" class="btn btn-success btn-lg col-md-5 col-md-offset-7">Next step <span class='fa fa-chevron-right'></span></button>
+		<button type="submit" class="btn btn-success btn-lg col-md-5">Next step <span class='fa fa-chevron-right'></span></button>
 	</form>
 {% endblock %}

--- a/brambling/templates/brambling/event/order/shop.html
+++ b/brambling/templates/brambling/event/order/shop.html
@@ -109,9 +109,6 @@
 						{% endif %}
 					</div>{# /.list-group #}
 				</div>
-				{% if next_step %}
-					{% include "brambling/event/order/_next_step_button.html" %}
-				{% endif %}
 			</div>
 			<div class="col-md-7 col-md-pull-5 margin-leader margin-leader-md-0">
 				{% for options in option_list %}

--- a/brambling/templates/brambling/event/order/shop.html
+++ b/brambling/templates/brambling/event/order/shop.html
@@ -9,25 +9,6 @@
 
 	{% if not user.is_authenticated or user.confirmed_email %}
 		{% include 'brambling/event/order/_use_discount_js.html' %}
-
-		<script>
-			$(function(){
-				$('a[target]').on('click', function(e){
-					if ($(this).attr('target') === '_blank') return true;
-					e.preventDefault();
-					$.post($(this).attr('target'), function(data){
-						// For now, just reload the page.
-						if (data.success) {
-							location.reload();
-						} else if (data.error) {
-							$('#items-list').before(
-								"<div class='alert alert-dismissable alert-danger'><button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;</button> " + data.error + "</div>"
-							);
-						}
-					});
-				})
-			});
-		</script>
 	{% endif %}
 
 	<script type="text/javascript" src="{% static "zenaida/js/bootstrap/carousel.js" %}"></script>

--- a/brambling/templates/brambling/event/order/summary.html
+++ b/brambling/templates/brambling/event/order/summary.html
@@ -29,17 +29,6 @@
 	{% endif %}
 {% endblock %}
 
-{% block next_step_button %}
-	<form class=''>
-		<div class='input-group input-group-lg'>
-			<input id='discountCode' class='form-control' placeholder='Discount code' autocomplete='off'>
-			<span class='input-group-btn'>
-				<button id='discountCodeButton' class='btn btn-success' type='submit' data-slug="{{ event.slug }}"><span class='fa fa-plus'></span></button>
-			</span>
-		</div>
-	</form>
-{% endblock %}
-
 {% block main %}
 	{% with next_step=1 %}
 		{{ block.super }}
@@ -152,7 +141,16 @@
 					</tbody>
 				</table>
 			</div>
-		</div>
+
+			<form class='margin-trailer'>
+				<div class='input-group input-group-lg'>
+					<input id='discountCode' class='form-control' placeholder='Discount code' autocomplete='off'>
+					<span class='input-group-btn'>
+						<button id='discountCodeButton' class='btn btn-success' type='submit' data-slug="{{ event.slug }}"><span class='fa fa-plus'></span></button>
+					</span>
+				</div>
+			</form>
+		</div>{# /.col-md-6 #}
 		<div class="col-md-6">
 			{% for attendee in attendees %}
 				<div class='panel panel-primary'>
@@ -206,9 +204,8 @@
 					</div>
 				</div>
 			{% endfor %}
-		</div>
-	</div>
-
+		</div>{# /.col-md-6#}
+	</div>{# /.row #}
 
 	{# START PAYMENT OPTIONS #}
 

--- a/brambling/templates/brambling/event/order/survey.html
+++ b/brambling/templates/brambling/event/order/survey.html
@@ -38,9 +38,8 @@
 	</script>
 {% endblock %}
 
-{% block next_step_button %}
-	<button type="submit" class="btn btn-success btn-lg btn-block">Next step <span class='fa fa-chevron-right'></span></button>
-{% endblock %}
+{# Don't display a next step button. The form's own button will suffice. #}
+{% block next_step_button %}{% endblock %}
 
 {% block main %}
 	<form action="" method="post" novalidate>
@@ -74,5 +73,6 @@
 				{% endfor %}
 			{% endform %}
 		</div>
+		<button type="submit" class="btn btn-success btn-lg col-md-5 col-md-offset-7">Next step <span class='fa fa-chevron-right'></span></button>
 	</form>
 {% endblock %}

--- a/brambling/templates/brambling/event/order/survey.html
+++ b/brambling/templates/brambling/event/order/survey.html
@@ -73,6 +73,6 @@
 				{% endfor %}
 			{% endform %}
 		</div>
-		<button type="submit" class="btn btn-success btn-lg col-md-5 col-md-offset-7">Next step <span class='fa fa-chevron-right'></span></button>
+		<button type="submit" class="btn btn-success btn-lg col-md-5">Next step <span class='fa fa-chevron-right'></span></button>
 	</form>
 {% endblock %}

--- a/brambling/templates/brambling/layouts/12.html
+++ b/brambling/templates/brambling/layouts/12.html
@@ -1,8 +1,10 @@
 {% extends "brambling/__base.html" %}
 
 {% block content %}
+	{% block before %}{% endblock %}
 	{% block messages %}
 		{% include "brambling/layouts/_messages.html" %}
 	{% endblock %}
 	{% block main %}{% endblock %}
+	{% block after %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
I updated the layout for all the order pages. In particular:

* The next step button never appears at the top of a page
* A cart button appears up there instead to remind you how many items you are buying
* The cart button prompts a modal that displays all the items in your cart
* The next step button _almost_ always will appear on the bottom right of the page, except when editing an attendee where a user must explicitly choose to save the attendee or cancel
* The next step button is always at the bottom on mobile!
* This whole thing works much better on mobile, I think, though the stepbar still needs love.

There's more that could be done in terms of polish here, but I think it's also ready to go as-is. I'm open to suggestions for this PR or to future polishing tickets.

* [x] Remove javascript in modal doesn't work.
* [x] Hosting page sucks.
* [x] Housing page sucks.