### PR TITLE
Added 'notes' tab to order management for admins.

### DIFF
--- a/brambling/forms/organizer.py
+++ b/brambling/forms/organizer.py
@@ -8,7 +8,7 @@ import floppyforms.__future__ as forms
 
 from brambling.models import (Attendee, Event, Item, ItemOption, Discount,
                               Date, ItemImage, Transaction, Invite, CustomForm,
-                              CustomFormField)
+                              CustomFormField, Order)
 from brambling.utils.international import clean_postal_code
 
 from zenaida.forms import (GroupedModelMultipleChoiceField,
@@ -355,3 +355,9 @@ class ManualDiscountForm(forms.Form):
 
     def save(self):
         self.order.add_discount(self.cleaned_data['discount'], force=True)
+
+
+class OrderNotesForm(forms.ModelForm):
+    class Meta:
+        model = Order
+        fields = ('notes',)

--- a/brambling/migrations/0025_order_notes.py
+++ b/brambling/migrations/0025_order_notes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('brambling', '0024_auto_20150323_1620'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='order',
+            name='notes',
+            field=models.TextField(blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/brambling/models.py
+++ b/brambling/models.py
@@ -709,6 +709,9 @@ class Order(AbstractDwollaModel):
 
     custom_data = GenericRelation('CustomFormEntry', content_type_field='related_ct', object_id_field='related_id')
 
+    # Admin-only data
+    notes = models.TextField(blank=True)
+
     class Meta:
         unique_together = ('event', 'code')
 

--- a/brambling/templates/brambling/event/organizer/order_detail.html
+++ b/brambling/templates/brambling/event/organizer/order_detail.html
@@ -53,17 +53,18 @@
 
 	<!-- Nav tabs -->
 	<ul class="nav nav-tabs" role="tablist">
-	  <li{% if not payment_form.is_bound and not discount_form.is_bound %} class="active"{% endif %}><a href="#summary" role="tab" data-toggle="tab">Order summary</a></li>
-	  <li{% if payment_form.is_bound %} class="active"{% endif %}><a href="#payment" role="tab" data-toggle="tab">Record payment</a></li>
-	  <li{% if discount_form.is_bound %} class="active"{% endif %}><a href="#discount" role="tab" data-toggle="tab">Apply discount</a></li>
+	  <li{% if active == 'summary' %} class="active"{% endif %}><a href="#summary" role="tab" data-toggle="tab">Order summary</a></li>
+	  <li{% if active == 'payment' %} class="active"{% endif %}><a href="#payment" role="tab" data-toggle="tab">Record payment</a></li>
+	  <li{% if active == 'discount' %} class="active"{% endif %}><a href="#discount" role="tab" data-toggle="tab">Apply discount</a></li>
+	  <li{% if active == 'notes' %} class="active"{% endif %}><a href="#notes" role="tab" data-toggle="tab">Notes</a></li>
 	</ul>
 
 	<!-- Tab panes -->
 	<div class="tab-content">
-		<div class="tab-pane{% if not payment_form.is_bound and not discount_form.is_bound %} active{% endif %}" id="summary">
+		<div class="tab-pane{% if active == 'summary' %} active{% endif %}" id="summary">
 			{% include "brambling/event/organizer/_admin_order_summary.html" %}
 		</div>
-		<div class="tab-pane{% if payment_form.is_bound %} active{% endif %}" id="payment">
+		<div class="tab-pane{% if active == 'payment' %} active{% endif %}" id="payment">
 			<div class='row'>
 				<div class='col-sm-6 col-sm-offset-3'>
 					<form method='post' action=''>
@@ -78,7 +79,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="tab-pane{% if discount_form.is_bound %} active{% endif %}" id="discount">
+		<div class="tab-pane{% if active == 'discount' %} active{% endif %}" id="discount">
 			<div class='row'>
 				<div class='col-sm-6 col-sm-offset-3'>
 					<form method='post' action=''>
@@ -86,6 +87,18 @@
 						{% csrf_token %}
 						{% form discount_form %}
 						<button type='submit' class='btn btn-primary'>Apply discount</button>
+					</form>
+				</div>
+			</div>
+		</div>
+		<div class="tab-pane{% if active == 'notes' %} active{% endif %}" id="notes">
+			<div class='row'>
+				<div class='col-sm-6 col-sm-offset-3'>
+					<form method='post' action='?active=notes'>
+						<input type='hidden' name='is_notes_form' value='1'>
+						{% csrf_token %}
+						{% form notes_form %}
+						<button type='submit' class='btn btn-primary'>Save notes</button>
 					</form>
 				</div>
 			</div>


### PR DESCRIPTION
Related to #242. Really, I think this should close #242. Adding notes field to attendees requires a much more invasive change, since we don't even have a way to view them in the admin right now.

Part of me wants to prioritize this, since we have a request from an event for notes functionality - but they might be looking for notes on attendee, not on order. Not sure.

This also needs to be added to the model table display, but I didn't want to much up the merge of the #409 branch by creating conflicts... Maybe I shouldn't worry about that, though.