### PR TITLE
Org static slug

### DIFF
--- a/brambling/forms/organizer.py
+++ b/brambling/forms/organizer.py
@@ -15,14 +15,11 @@ from brambling.utils.payment import LIVE, TEST
 from zenaida.forms import (GroupedModelMultipleChoiceField,
                            GroupedModelChoiceField)
 
-STATIC_ORGANIZATION_SLUGS = frozenset(('demo', 'demo-event'))
-STATIC_EVENT_SLUGS = frozenset(('demo-event',))
-
 
 class OrganizationProfileForm(forms.ModelForm):
     def __init__(self, request, *args, **kwargs):
         super(OrganizationProfileForm, self).__init__(*args, **kwargs)
-        if self.instance.slug in STATIC_ORGANIZATION_SLUGS:
+        if self.instance.is_demo():
             del self.fields['slug']
 
     class Meta:
@@ -213,7 +210,7 @@ class EventForm(forms.ModelForm):
             if (timezone, timezone) not in self.fields['timezone'].choices:
                 self.fields['timezone'].choices += ((timezone, timezone),)
 
-        if self.instance.slug in STATIC_EVENT_SLUGS:
+        if self.instance.is_demo():
             del self.fields['slug']
 
     def clean_editors(self):

--- a/brambling/forms/organizer.py
+++ b/brambling/forms/organizer.py
@@ -210,7 +210,7 @@ class EventForm(forms.ModelForm):
             if (timezone, timezone) not in self.fields['timezone'].choices:
                 self.fields['timezone'].choices += ((timezone, timezone),)
 
-        if self.instance.is_demo():
+        if self.instance.is_demo() and self.instance.pk:
             del self.fields['slug']
 
     def clean_editors(self):
@@ -234,6 +234,8 @@ class EventForm(forms.ModelForm):
 
     def save(self):
         created = self.instance.pk is None
+        if self.instance.is_demo():
+            self.instance.api_type = Event.TEST
         instance = super(EventForm, self).save()
 
         if {'start_date', 'end_date'} & set(self.changed_data) or created:

--- a/brambling/models.py
+++ b/brambling/models.py
@@ -271,6 +271,8 @@ class Date(models.Model):
 
 
 class Organization(AbstractDwollaModel):
+    DEMO_SLUG = 'demo'
+
     name = models.CharField(max_length=50)
     slug = models.SlugField(max_length=50,
                             validators=[RegexValidator("^[a-z0-9-]+$")],
@@ -357,6 +359,9 @@ class Organization(AbstractDwollaModel):
     def get_invites(self):
         return Invite.objects.filter(kind=Invite.ORGANIZATION_EDITOR,
                                      content_id=self.pk)
+
+    def is_demo(self):
+        return self.slug == Organization.DEMO_SLUG
 
 
 class EventQuerySet(models.QuerySet):
@@ -500,6 +505,9 @@ class Event(models.Model):
         if self.api_type == Event.LIVE:
             return self.organization.dwolla_live_can_connect()
         return self.organization.dwolla_test_can_connect()
+
+    def is_demo(self):
+        return self.organization.is_demo()
 
 
 class Item(models.Model):

--- a/brambling/templates/brambling/forms/event.html
+++ b/brambling/templates/brambling/forms/event.html
@@ -218,5 +218,9 @@
 				<div class="col-sm-4"><div class='alert {% if check %}alert-success{% else %}alert-danger{% endif %}'><i class='fa fa-fw {% if check %}fa-check{% else %}fa-ban{% endif %}'></i> Check</div></div>
 			{% endwith %}
 		</div>{# /.row #}
+
+		{% if event.is_demo %}
+			<p class='text-muted'>Note: This is a demo event which uses test APIs. None of the transactions made through this event can result in real money changing hands.</p>
+		{% endif %}
 	</div>{# /.panel-body #}
 </div>{# /.panel #}

--- a/brambling/templates/brambling/organization/payment.html
+++ b/brambling/templates/brambling/organization/payment.html
@@ -34,6 +34,7 @@
 					</tr>
 				</thead>
 				<tbody>
+				{% if not organization.is_demo %}
 					{# Stripe / Dwolla Live: #}
 					{% if organization.stripe_live_connected or stripe_oauth_url %}
 						<tr>
@@ -71,7 +72,7 @@
 							{% endif %}
 						</tr>
 					{% endif %}
-
+				{% else %}
 					{# Stripe / Dwolla Test: #}
 					{% if request.user.is_superuser %}
 						{% if organization.stripe_test_connected or stripe_test_oauth_url %}
@@ -111,6 +112,7 @@
 							</tr>
 						{% endif %}
 					{% endif %}
+				{% endif %}
 
 					{# By Mail/Check: #}
 					<tr>
@@ -161,6 +163,10 @@
 				</tbody>
 			</table>
 		{% endform %}
+
+		{% if organization.is_demo %}
+			<p class='text-muted'>Note: This is a demo organization which uses test APIs. None of the transactions made through this organization can result in real money changing hands.</p>
+		{% endif %}
 
 		<button class="btn btn-primary" type="submit">
 			Save Changes

--- a/brambling/templates/brambling/organization/profile.html
+++ b/brambling/templates/brambling/organization/profile.html
@@ -23,7 +23,7 @@
 					Slug
 					 <span class="required">*</span>
 					</label>
-					<input class="form-control" type="text" value="{{ event.slug }}" disabled>
+					<input class="form-control" type="text" value="{{ organization.slug }}" disabled>
 					<p class="help-block">{{ form.base_fields.slug.help_text }}</p>
 				</div>
 			{% endif %}


### PR DESCRIPTION
This commit is basically a cleanup of things related to demo organizations. It provides two simple methods – `Organization.is_demo()` and `Event.is_demo()` – which can be used to check whether the organization or event is a demo.

In practical terms, this PR results in a few extra bits of helpful text being displayed, slugs not being modifiable, and new events being set to use test APIs.

It *might* make more sense to handle the demo slug as a setting rather than an attribute on Organization, but this is easier and it's not really ever going to be customized...