### PR TITLE
Email confirmation improvements

### DIFF
--- a/brambling/templates/brambling/email_confirm.html
+++ b/brambling/templates/brambling/email_confirm.html
@@ -1,14 +1,29 @@
-{% extends "brambling/layouts/12.html" %}
+{% extends "brambling/layouts/12_xs.html" %}
 
-{% block title %}Email confirmed – {{ block.super }}{% endblock %}
+{% block title %}{% if valid_token %}Email confirmed{% else %}Invalid token{% endif %} – {{ block.super }}{% endblock %}
 
 {% block meta %}
     {{ block.super }}
-    <meta http-equiv="refresh" content="3; url={% url 'brambling_dashboard' %}">
+
+	{% if valid_token %}
+	    <meta http-equiv="refresh" content="3; url={% url 'brambling_dashboard' %}">
+   {% endif %}
 {% endblock %}
 
 {% block main %}
-    <div class="alert alert-success">
-        Your email address has been confirmed! You will be redirected to <a href="{% url 'brambling_dashboard' %}">your dashboard</a> in a few seconds.
-    </div>
+	{% if valid_token %}
+	    <div class="alert alert-success">
+	        Your email address has been confirmed! You will be redirected to <a href="{% url 'brambling_dashboard' %}">your dashboard</a> in a few seconds.
+	    </div>
+	{% else %}
+		<p>
+			Sorry, but the email confirmation link you followed is no longer valid.
+			It probably expired or has already been used.
+		</p>
+		{% if request.user.is_authenticated %}
+			<p>If you think this is in error, please <a href='{% url "brambling_email_confirm_send" %}'>request a new confirmation link</a>. Thanks!</p>
+		{% else %}
+			<p>If you think this is in error, please log in to request a new confirmation link.</p>
+		{% endif %}
+	{% endif %}
 {% endblock %}

--- a/brambling/templates/brambling/event/order/shop.html
+++ b/brambling/templates/brambling/event/order/shop.html
@@ -7,9 +7,7 @@
 {% block javascripts %}
 	{{ block.super }}
 
-	{% if not user.is_authenticated or user.confirmed_email %}
-		{% include 'brambling/event/order/_use_discount_js.html' %}
-	{% endif %}
+	{% include 'brambling/event/order/_use_discount_js.html' %}
 
 	<script type="text/javascript" src="{% static "zenaida/js/bootstrap/carousel.js" %}"></script>
 {% endblock %}
@@ -85,9 +83,6 @@
 								</span>
 							</div>
 						</div>
-						{% if user.is_authenticated and not user.confirmed_email %}
-							<div class="scrim"></div>
-						{% endif %}
 					</div>{# /.list-group #}
 				</div>
 			</div>
@@ -150,7 +145,7 @@
 						</header>
 						<div class='list-group relative'>
 							{% for option in options.list %}
-								<a{% if not user.is_authenticated or user.confirmed_email %} target='{% if code_in_url %}{% url "brambling_event_shop_add" event_slug=event.slug organization_slug=event.organization.slug pk=option.pk code=order.code %}{% else %}{% url "brambling_event_shop_add" event_slug=event.slug organization_slug=event.organization.slug pk=option.pk %}{% endif %}'{% endif %} href='javascript://' class="list-group-item {% if option.total_number and option.remaining <= 0 %} disabled{% endif %}">
+								<a target='{% if code_in_url %}{% url "brambling_event_shop_add" event_slug=event.slug organization_slug=event.organization.slug pk=option.pk code=order.code %}{% else %}{% url "brambling_event_shop_add" event_slug=event.slug organization_slug=event.organization.slug pk=option.pk %}{% endif %}' href='javascript://' class="list-group-item {% if option.total_number and option.remaining <= 0 %} disabled{% endif %}">
 									<div class='row'>
 										<div class='col-xs-12 col-sm-6'>
 											{{ option.name }}
@@ -174,9 +169,6 @@
 									</div>
 								</a>
 							{% endfor %}
-							{% if user.is_authenticated and not user.confirmed_email %}
-								<div class="scrim"></div>
-							{% endif %}
 						</div>
 					</div>
 				{% endfor %}

--- a/brambling/templates/brambling/forms/person.html
+++ b/brambling/templates/brambling/forms/person.html
@@ -25,7 +25,12 @@
 		{% if form.instance.name_order == "GMS" and form.instance.middle_name == "" %}
 			<small><a href="#nameOptions" data-toggle="collapse" class="pull-right more-name-options"><i class="fa fa-plus"></i> More Name Options</a></small>
 		{% endif %}
-		{% formrow form.email %}
+		{% if person.email != person.confirmed_email %}
+			{% url "brambling_email_confirm_send" as send_url %}
+			{% formrow form.email with help_text="<a href='"|add:send_url|add:"'>Request a confirmation email</a>"|safe %}
+		{% else %}
+			{% formrow form.email %}
+		{% endif %}
 		{% formrow form.phone %}
 	</div>
 </div>{# /.panel #}

--- a/brambling/templates/brambling/layouts/_messages.html
+++ b/brambling/templates/brambling/layouts/_messages.html
@@ -6,6 +6,3 @@
 		</div>
 	{% endfor %}
 {% endif %}
-{% if user.is_authenticated and not user.confirmed_email %}
-	<div class='alert alert-warning'>You must confirm your email address to register for events. <a class='alert-link' href="{% url 'brambling_email_confirm_send' %}">Resend confirmation email</a></div>
-{% endif %}

--- a/brambling/views/core.py
+++ b/brambling/views/core.py
@@ -90,6 +90,9 @@ class InviteAcceptView(TemplateView):
             invite = None
         else:
             if request.user.is_authenticated() and request.user.email == invite.email:
+                if request.user.confirmed_email != request.user.email:
+                    request.user.confirmed_email = request.user.email
+                    request.user.save()
                 if invite.kind == Invite.EVENT_EDITOR:
                     event = Event.objects.get(pk=invite.content_id)
                     event.additional_editors.add(request.user)

--- a/brambling/views/orders.py
+++ b/brambling/views/orders.py
@@ -396,10 +396,8 @@ class AddToOrderView(OrderMixin, View):
         if item_option.total_number is not None and item_option.remaining <= 0:
             return JsonResponse({'success': False, 'error': 'That item is sold out.'})
 
-        if self.order.person is None or self.order.person.confirmed_email or self.is_admin_request:
-            self.order.add_to_cart(item_option)
-            return JsonResponse({'success': True})
-        return JsonResponse({'success': False})
+        self.order.add_to_cart(item_option)
+        return JsonResponse({'success': True})
 
     def get_order(self):
         order = super(AddToOrderView, self).get_order()

--- a/brambling/views/user.py
+++ b/brambling/views/user.py
@@ -55,11 +55,12 @@ class EmailConfirmView(DetailView):
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
-        if not self.generator.check_token(self.object, self.kwargs['token']):
-            raise Http404("Token invalid or expired.")
-        self.object.confirmed_email = self.object.email
-        self.object.save()
+        valid_token = self.generator.check_token(self.object, self.kwargs['token'])
+        if valid_token:
+            self.object.confirmed_email = self.object.email
+            self.object.save()
         context = self.get_context_data(object=self.object)
+        context['valid_token'] = valid_token
         return self.render_to_response(context)
 
 


### PR DESCRIPTION
Some minor cleanup / improvements to email confirmation behavior. Resolved #362 and #479. Users can now register without confirming their email address, accepting an invitation confirms your address, and invalid tokens give you an informative message & resend link rather than a 404 error.

#246 (claiming old orders) is more involved, so I figured it would be best to keep as a separate ticket.