### PR TITLE
Added links to remote payment detail pages from finances view.

### DIFF
--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -21,6 +21,7 @@
                     <th>Amount</th>
                     <th>Dancerfly Fee</th>
                     <th>Payment Fee</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -35,6 +36,13 @@
                         <td>{{ transaction.amount|format_money:event.currency }}</td>
                         <td>{{ transaction.application_fee|format_money:event.currency }}</td>
                         <td>{{ transaction.processing_fee|format_money:event.currency }}</td>
+                        <td>
+                            {% if transaction.get_remote_url %}
+                                <a class='btn btn-primary' href="{{ transaction.get_remote_url }}" target='_blank'>
+                                    View on {{ transaction.get_method_display }}
+                                    <i class='fa fa-fw fa-external-link'></i>
+                                </a>
+                            {% endif %}
                     </tr>
                 {% endfor %}
                 {% endtimezone %}

--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -43,6 +43,7 @@
                                     <i class='fa fa-fw fa-external-link'></i>
                                 </a>
                             {% endif %}
+                        </td>
                     </tr>
                 {% endfor %}
                 {% endtimezone %}

--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -38,7 +38,7 @@
                         <td>{{ transaction.processing_fee|format_money:event.currency }}</td>
                         <td>
                             {% if transaction.get_remote_url %}
-                                <a class='btn btn-primary' href="{{ transaction.get_remote_url }}" target='_blank'>
+                                <a class='btn btn-default' href="{{ transaction.get_remote_url }}" target='_blank'>
                                     View on {{ transaction.get_method_display }}
                                     <i class='fa fa-fw fa-external-link'></i>
                                 </a>

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -943,7 +943,7 @@ class FinancesView(ListView):
         return super(FinancesView, self).get_queryset().filter(
             event=self.event,
             api_type=self.event.api_type,
-        ).select_related('created_by', 'order').order_by('-timestamp')
+        ).select_related('created_by', 'order', 'related_transaction').order_by('-timestamp')
 
     def get_context_data(self, **kwargs):
         context = super(FinancesView, self).get_context_data(**kwargs)


### PR DESCRIPTION
Resolved #508.

I've tested this; the links seem to work properly for stripe vs. dwolla, test vs. live, and purchase vs. refund.