### PR TITLE
Allow exporting the Finances table as a CSV

### DIFF
--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -18,30 +18,26 @@
     <div class="scroll-x">
         <table class="table table-striped">
             <thead>
-                <tr>
-                    <th>Timestamp <span class='text-muted'>{{ event.timezone }}</span></th>
-                    <th>Created by</th>
-                    <th>Method</th>
-                    <th>Type</th>
-                    <th>Order</th>
-                    <th>Amount</th>
-                    <th>Dancerfly Fee</th>
-                    <th>Payment Fee</th>
-                    <th></th>
-                </tr>
+              <tr>
+                {% for header in table.headers %}
+                <th>{{ header }}</th>
+                {% endfor %}
+                <th></th>
+              </tr>
             </thead>
             <tbody>
                 {% timezone event.timezone %}
-                {% for transaction in transactions %}
-                    <tr>
-                        <td>{{ transaction.timestamp|date:"F jS, Y H:i:s" }}</td>
-                        <td>{% if transaction.created_by %}{{ transaction.created_by.get_full_name }}{% endif %}</td>
-                        <td>{{ transaction.get_method_display }}</td>
-                        <td>{{ transaction.get_transaction_type_display }}</td>
-                        <td>{% if transaction.order %}<a href="{% url 'brambling_event_order_detail' event_slug=event.slug organization_slug=event.organization.slug code=transaction.order.code %}">{{ transaction.order.code }}</a>{% endif %}</td>
-                        <td>{{ transaction.amount|format_money:event.currency }}</td>
-                        <td>{{ transaction.application_fee|format_money:event.currency }}</td>
-                        <td>{{ transaction.processing_fee|format_money:event.currency }}</td>
+                {% for row in table.cell_rows %}
+                <tr>
+                  {% for cell in row %}
+                  <td>
+                    {% if cell.field == 'Order' and cell.value != '' %}
+                    <a href="{% url 'brambling_event_order_detail' event_slug=event.slug organization_slug=event.organization.slug code=cell %}">{{ cell }}</a>
+                    {% else %}
+                    {{cell.value}}
+                    {% endif %}
+                  </td>
+                  {% endfor %}
                         <td>
                             {% if transaction.get_remote_url %}
                                 <a class='btn btn-default' href="{{ transaction.get_remote_url }}" target='_blank'>

--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -31,7 +31,7 @@
                 <tr>
                   {% for cell in row %}
                   <td>
-                    {% if cell.field == 'Order' and cell.value != '' %}
+                    {% if cell.field == 'order' and cell.value != '' %}
                     <a href="{% url 'brambling_event_order_detail' event_slug=event.slug organization_slug=event.organization.slug code=cell %}">{{ cell }}</a>
                     {% else %}
                     {{cell.value}}

--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -27,7 +27,7 @@
             </thead>
             <tbody>
                 {% timezone event.timezone %}
-                {% for row in table.cell_rows %}
+                {% for row in table.get_rows %}
                 <tr>
                   {% for cell in row %}
                   <td>

--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -8,6 +8,12 @@
     {{ block.super }}
     {% include "brambling/event/_empty_shop_alert.html" %}
 
+    <form>
+      <button type="submit" class="btn btn-sm btn-default tipped" name="format" value="csv" title="Download CSV" data-container="body">
+        <i class="fa fa-download"></i>
+        <span class='hidden-sm hidden-md'>Download CSV</span>
+      </button>
+    </form>
 
     <div class="scroll-x">
         <table class="table table-striped">

--- a/brambling/tests/functional/test_finance_table.py
+++ b/brambling/tests/functional/test_finance_table.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+
+from brambling.utils.model_tables import Cell
+from brambling.views.utils import FinanceTable
+from brambling.tests.factories import TransactionFactory, EventFactory, \
+    PersonFactory, OrderFactory
+
+
+class FinanceTableTestCase(TestCase):
+
+    def setUp(self):
+        self.order = OrderFactory(code='TK421')
+        self.event = EventFactory()
+        self.transactions = [TransactionFactory(order=self.order)]
+
+    def test_assert_true(self):
+        assert True
+
+    def test_headers(self):
+        table = FinanceTable(self.event, self.transactions)
+        self.assertEqual(len(table.headers()), 8)
+
+    def test_plaintext_row_count(self):
+        # headers are considered part of the plaintext table
+        table = FinanceTable(self.event, self.transactions)
+        self.assertEqual(len(list(table.plaintext_rows())), 2)
+
+    def test_cell_row_count(self):
+        # cells do not include headers
+        table = FinanceTable(self.event, self.transactions)
+        self.assertEqual(len(list(table.cell_rows())), 1)
+
+    def test_transaction_created_by_blank(self):
+        name = FinanceTable.created_by_name(TransactionFactory())
+        self.assertEqual('', name)
+
+    def test_transaction_created_by_name(self):
+        creator = PersonFactory(given_name='Leia', surname='Organa')
+        created_transaction = TransactionFactory(created_by=creator)
+        name = FinanceTable.created_by_name(created_transaction)
+        self.assertEqual('Leia Organa', name)
+
+    def test_transaction_with_order_code(self):
+        code = FinanceTable.order_code(self.transactions[0])
+        self.assertEqual('TK421', code)
+
+    def test_transaction_without_order(self):
+        transaction = TransactionFactory(order=None)
+        code = FinanceTable.order_code(transaction)
+        self.assertEqual('', code)
+
+    def test_transaction_as_cell_row(self):
+        table = FinanceTable(self.event, self.transactions)
+        row = list(table.cell_rows())[0]
+        self.assertEqual(len(row), 8)
+        self.assertEqual(row[4].field, 'order')
+        self.assertEqual(row[4].value, 'TK421')

--- a/brambling/tests/functional/test_finance_table.py
+++ b/brambling/tests/functional/test_finance_table.py
@@ -1,9 +1,8 @@
 from django.test import TestCase
 
-from brambling.utils.model_tables import Cell
 from brambling.views.utils import FinanceTable
-from brambling.tests.factories import TransactionFactory, EventFactory, \
-    PersonFactory, OrderFactory
+from brambling.tests.factories import (TransactionFactory, EventFactory,
+                                       PersonFactory, OrderFactory)
 
 
 class FinanceTableTestCase(TestCase):

--- a/brambling/tests/functional/test_finance_table.py
+++ b/brambling/tests/functional/test_finance_table.py
@@ -11,46 +11,38 @@ class FinanceTableTestCase(TestCase):
         self.order = OrderFactory(code='TK421')
         self.event = EventFactory()
         self.transactions = [TransactionFactory(order=self.order)]
-
-    def test_assert_true(self):
-        assert True
+        self.table = FinanceTable(self.event, self.transactions)
 
     def test_headers(self):
-        table = FinanceTable(self.event, self.transactions)
-        self.assertEqual(len(table.headers()), 8)
+        self.assertEqual(len(self.table.headers()), 8)
 
-    def test_plaintext_row_count(self):
-        # headers are considered part of the plaintext table
-        table = FinanceTable(self.event, self.transactions)
-        self.assertEqual(len(list(table.plaintext_rows())), 2)
+    def test_row_count(self):
+        self.assertEqual(len(list(self.table.get_rows())), 1)
 
-    def test_cell_row_count(self):
-        # cells do not include headers
-        table = FinanceTable(self.event, self.transactions)
-        self.assertEqual(len(list(table.cell_rows())), 1)
+    def test_inclusion_of_header_row(self):
+        self.assertEqual(len(list(self.table.get_rows(include_headers=True))), 2)
 
     def test_transaction_created_by_blank(self):
-        name = FinanceTable.created_by_name(TransactionFactory())
+        name = self.table.created_by_name(TransactionFactory())
         self.assertEqual('', name)
 
     def test_transaction_created_by_name(self):
         creator = PersonFactory(given_name='Leia', surname='Organa')
         created_transaction = TransactionFactory(created_by=creator)
-        name = FinanceTable.created_by_name(created_transaction)
+        name = self.table.created_by_name(created_transaction)
         self.assertEqual('Leia Organa', name)
 
     def test_transaction_with_order_code(self):
-        code = FinanceTable.order_code(self.transactions[0])
+        code = self.table.order_code(self.transactions[0])
         self.assertEqual('TK421', code)
 
     def test_transaction_without_order(self):
         transaction = TransactionFactory(order=None)
-        code = FinanceTable.order_code(transaction)
+        code = self.table.order_code(transaction)
         self.assertEqual('', code)
 
     def test_transaction_as_cell_row(self):
-        table = FinanceTable(self.event, self.transactions)
-        row = list(table.cell_rows())[0]
+        row = list(self.table.get_rows())[0]
         self.assertEqual(len(row), 8)
         self.assertEqual(row[4].field, 'order')
         self.assertEqual(row[4].value, 'TK421')

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -1024,8 +1024,8 @@ class FinancesView(ListView):
 
             pseudo_buffer = Echo()
             writer = csv.writer(pseudo_buffer)
-            response = StreamingHttpResponse((writer.writerow([unicode(cell) for cell in row])
-                                              for row in table.plaintext_rows()),
+            response = StreamingHttpResponse((writer.writerow([unicode(cell.value) for cell in row])
+                                              for row in table.get_rows(include_headers=True)),
                                              content_type="text/csv")
             response['Content-Disposition'] = 'attachment; filename="finances.csv"'
             return response

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -37,7 +37,7 @@ from brambling.views.orders import OrderMixin, ApplyDiscountView
 from brambling.views.utils import (get_event_admin_nav,
                                    get_organization_admin_nav,
                                    clear_expired_carts,
-                                   ajax_required)
+                                   ajax_required, FinanceTable)
 from brambling.utils.model_tables import Echo, AttendeeTable, OrderTable
 from brambling.utils.payment import (dwolla_organization_oauth_url,
                                      stripe_organization_oauth_url,
@@ -1011,3 +1011,23 @@ class FinancesView(ListView):
             'event_admin_nav': get_event_admin_nav(self.event, self.request),
         })
         return context
+
+    def render_to_response(self, context, *args, **kwargs):
+        "Return a response in the requested format."
+
+        format_ = self.request.GET.get('format', default='html')
+
+        if format_ == 'csv':
+            context = super(FinancesView, self).get_context_data(**kwargs)
+            table = FinanceTable(self.event, context['transactions'])
+
+            pseudo_buffer = Echo()
+            writer = csv.writer(pseudo_buffer)
+            response = StreamingHttpResponse((writer.writerow([unicode(cell) for cell in row])
+                                              for row in table.all_rows()),
+                                             content_type="text/csv")
+            response['Content-Disposition'] = 'attachment; filename="finances.csv"'
+            return response
+
+        # Default to the template.
+        return super(ListView, self).render_to_response(context, *args, **kwargs)

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -1009,6 +1009,7 @@ class FinancesView(ListView):
         context.update({
             'event': self.event,
             'event_admin_nav': get_event_admin_nav(self.event, self.request),
+            'table': FinanceTable(self.event, context['transactions']),
         })
         return context
 
@@ -1024,7 +1025,7 @@ class FinancesView(ListView):
             pseudo_buffer = Echo()
             writer = csv.writer(pseudo_buffer)
             response = StreamingHttpResponse((writer.writerow([unicode(cell) for cell in row])
-                                              for row in table.all_rows()),
+                                              for row in table.plaintext_rows()),
                                              content_type="text/csv")
             response['Content-Disposition'] = 'attachment; filename="finances.csv"'
             return response

--- a/brambling/views/utils.py
+++ b/brambling/views/utils.py
@@ -248,23 +248,14 @@ class FinanceTable(object):
             'Payment Fee',
         ]
 
-    def header_row(self):
-        return [self.headers()]
+    def header_cells(self):
+        return [Cell(field='header', value=col) for col in self.headers()]
 
-    def plaintext_rows(self):
-        yield self.headers()
-        for transaction in self.transactions:
-            yield [c.value for c in self.format_transaction(transaction)]
-
-    def cell_rows(self):
+    def get_rows(self, include_headers=False):
+        if include_headers:
+            yield self.header_cells()
         for transaction in self.transactions:
             yield self.format_transaction(transaction)
-
-    def transaction_rows(self):
-        return islice(self.all_rows(), 1, None)
-
-    def transaction_as_cell_row(self, transaction):
-        return self.format_transaction(transaction)
 
     def money(self, amount):
         return format_money(amount, self.event.currency)
@@ -289,15 +280,13 @@ class FinanceTable(object):
         localtime = timezone.localtime(transaction.timestamp, timezone=tz)
         return localtime.strftime("%B %d, %Y %H:%M:%S")
 
-    @classmethod
-    def order_code(cls, transaction):
+    def order_code(self, transaction):
         if transaction.order:
             return transaction.order.code
         else:
             return ''
 
-    @classmethod
-    def created_by_name(cls, transaction):
+    def created_by_name(self, transaction):
         if transaction.created_by:
             return transaction.created_by.get_full_name()
         else:


### PR DESCRIPTION
Puts a button the Finances page that exports what's on the table as a CSV. 

Implementation-wise, it's highly possible this could be more idiomatically Django. My strategy was to make a Python class that controls the formatting logic (which I copied from the template) and call it from the view. In theory this class could also be used to generate the data in the template -- with some tweaking (e.g. generating a link for the order number). 

Possible open questions:

 * Button positioning. It doesn't match the Attendees or Orders pages, but is possibly more obvious without all the rest of the controls. My technique here is called "don't mess with CSS until absolutely necessary."
 * I might be doing unnecessary work to get the timezone right in `format_timestamp`. The template uses a special function I couldn't really get to work in the view.
 * It worked for my trivial data set (1 transaction), but it might not for something larger. If there's an easy way for me to get a bunch of seed data, that could be handy. Or at least test the CSV code against something more closely resembling the actual data.

So! Hope it seems good.