### PR TITLE
Facebook URL needs to here to be in the form. Refs #575

### DIFF
--- a/brambling/forms/organizer.py
+++ b/brambling/forms/organizer.py
@@ -180,7 +180,7 @@ class EventForm(forms.ModelForm):
                   'has_dances', 'has_classes', 'liability_waiver', 'privacy',
                   'collect_housing_data', 'collect_survey_data',
                   'cart_timeout', 'start_date', 'end_date',
-                  'check_postmark_cutoff')
+                  'check_postmark_cutoff', 'facebook_url')
         widgets = {
             'country': forms.Select,
         }


### PR DESCRIPTION
I put `facebook_url` in the `EventForm`'s list of fields and, ta-da, it shows back up on the update/create event forms. 

Also, I did a little history-diving and it's not totally clear to me if this field used to be in the list and was removed, or never was there to begin with. So, I hope its being gone was just an oversight and not something intentional. That is, I'm not totally sure this addition doesn't unexpectedly change something besides the event forms. But I'm fairly sure?