### PR TITLE
Correct validation help text.

### DIFF
--- a/brambling/forms/organizer.py
+++ b/brambling/forms/organizer.py
@@ -243,8 +243,8 @@ class EventForm(forms.ModelForm):
         cleaned_data = super(EventForm, self).clean()
         if ('start_date' in cleaned_data and 'end_date' in cleaned_data and
                 cleaned_data['start_date'] > cleaned_data['end_date']):
-            raise ValidationError("End date must be before or equal to "
-                                  "the start date.")
+            raise ValidationError("Start date must be before or equal to "
+                                  "the end date.")
         return cleaned_data
 
     def save(self):


### PR DESCRIPTION
I think the words start & end got swapped in the validation error message for "Start Date" and "End Date" for events.