### PR TITLE
Switched fully-discounted transactions to use NONE instead of FAKE.

### DIFF
--- a/brambling/views/orders.py
+++ b/brambling/views/orders.py
@@ -658,7 +658,7 @@ class SummaryView(OrderMixin, WorkflowMixin, TemplateView):
             valid = True
             payment = Transaction.objects.create(
                 amount=0,
-                method=Transaction.FAKE,
+                method=Transaction.NONE,
                 transaction_type=Transaction.PURCHASE,
                 is_confirmed=True,
                 api_type=self.event.api_type,


### PR DESCRIPTION
The NONE transaction type is newer and more clearly represents what's going on.