### PR TITLE
Informative error pages

### DIFF
--- a/brambling/templates/404.html
+++ b/brambling/templates/404.html
@@ -1,18 +1,26 @@
 {% extends 'brambling/layouts/12.html' %}
 
+{% load staticfiles %}
+
 {% block title %}404 Error – {{ block.super }}{% endblock %}
 
 {% block main %}
-<h1>404 Not Found</h1>
-<p>No page was found at:</p>
-<pre id="url"></pre>
+<div class='row'>
+	<div class='col-xs-6 col-xs-offset-3'>
+		<h1>404 Not Found</h1>
+		<p>Uh oh! No page was found at:</p>
+		<pre id="url"></pre>
 
-<p>But don't panic, try one of these:</p>
-<ul>
-  <li><a href="/">Visit the Dancerfly homepage</a></li>
-  <li><a href="javascript: history.go(-1)">Go back to the page that sent you here</a></li>
-  <li><a href="mailto:support@dancerfly.com" >Email Dancerfly for help</a> or use the feedback tool in the lower right.</li>
-</ul>
+		<p>But don't panic, try one of these:</p>
+		<ul>
+			<li><a href="/">Visit the Dancerfly homepage</a></li>
+			<li><a href="javascript: history.go(-1)">Go back to the page that sent you here</a></li>
+			<li><a href="mailto:support@dancerfly.com" >Email Dancerfly for help</a> or use the feedback tool in the lower right.</li>
+		</ul>
+	</div>
+</div>
+
+<img src='{% static "brambling/images/all-dancers.gif" %}' class='full-width'>
 
 <script type="text/javascript">
  document.getElementById("url").innerHTML = window.location.href;

--- a/brambling/templates/404.html
+++ b/brambling/templates/404.html
@@ -3,7 +3,18 @@
 {% block title %}404 Error – {{ block.super }}{% endblock %}
 
 {% block main %}
-	<h1>404 errors, all in a line</h1>
-	<p>All of them good ones, all of them lies.</p>
-{% endblock main %}
+<h1>404 Not Found</h1>
+<p>No page was found at:</p>
+<pre id="url"></pre>
 
+<p>But don't panic, try one of these:</p>
+<ul>
+  <li><a href="/">Visit the Dancerfly homepage</a></li>
+  <li><a href="javascript: history.go(-1)">Go back to the page that sent you here</a></li>
+  <li><a href="mailto:support@dancerfly.com" >Email Dancerfly for help</a> or use the feedback tool in the lower right.</li>
+</ul>
+
+<script type="text/javascript">
+ document.getElementById("url").innerHTML = window.location.href;
+</script>
+{% endblock main %}

--- a/brambling/templates/500.html
+++ b/brambling/templates/500.html
@@ -3,8 +3,13 @@
 {% block title %}500 Error – {{ block.super }}{% endblock %}
 
 {% block main %}
-	<h1>500 errors is a lot of errors.</h1>
-	<p>Let us know you got here? You can use the feedback tool in the lower right.</p>
+	<h1>500 Error</h1>
+    <p>Seems like an error has occurred. But don't worry, here's what you can do about it:</p>
+    <ul>
+        <li>Try again by reloading the page. Maybe it was a temporary glitch.</li>
+        <li>Let us know you got here? You can email <a href="mailto:support@dancerfly.com">support@dancerfly.com</a> or use the feedback tool in the lower right.</li>
+        <li>If you aren't sure how you got here, try the <a href="/">Dancerfly homepage</a></li>
+    </ul>
+
 	<p>We look forward to hearing from you. Perferably about things that aren't errors. But, you know, we want to hear about the errors, too.</p>
 {% endblock main %}
-

--- a/brambling/templates/500.html
+++ b/brambling/templates/500.html
@@ -1,15 +1,23 @@
 {% extends 'brambling/layouts/12.html' %}
 
+{% load staticfiles %}
+
 {% block title %}500 Error – {{ block.super }}{% endblock %}
 
 {% block main %}
-	<h1>500 Error</h1>
-    <p>Seems like an error has occurred. But don't worry, here's what you can do about it:</p>
-    <ul>
-        <li>Try again by reloading the page. Maybe it was a temporary glitch.</li>
-        <li>Let us know you got here? You can email <a href="mailto:support@dancerfly.com">support@dancerfly.com</a> or use the feedback tool in the lower right.</li>
-        <li>If you aren't sure how you got here, try the <a href="/">Dancerfly homepage</a></li>
-    </ul>
+<div class='row'>
+	<div class='col-xs-6 col-xs-offset-3'>
+		<h1>500 Error</h1>
+		<p>Seems like an error has occurred. But don't worry, here's what you can do about it:</p>
+		<ul>
+			<li>Unless you were submitting a form, try reloading the page. Maybe it was a temporary glitch?</li>
+			<li>Let us know how you got here! Help us fix this error by emailing <a href="mailto:support@dancerfly.com">support@dancerfly.com</a> or using the feedback tool in the lower right.</li>
+			<li>If all else fails, try going to the <a href="/">Dancerfly homepage</a> and finding your way from there.</li>
+		</ul>
 
-	<p>We look forward to hearing from you. Perferably about things that aren't errors. But, you know, we want to hear about the errors, too.</p>
+		<p>We look forward to hearing from you. Preferably about things that aren't errors. But, you know, we want to hear about the errors, too. ;-)</p>
+	</div>
+</div>
+
+<img src='{% static "brambling/images/all-dancers.gif" %}' class='full-width'>
 {% endblock main %}


### PR DESCRIPTION
See issue #578 for original issue.

Adds a couple options, including the support email, to the 404 and 500 pages. Also includes an explicit link to the home page, in case people don't know what's going on at all. I actually feel like there could be more text here, given that it's highly possible people will encounter these pages via links from external sites (e.g. Dance organizations). If someone clicks, say, an outdated "purchase tickets" link on a totally different website, they could be very confused.

So it might make sense in the future to have more fine-grained errors like "Organization not found" or "Dance event not found" or "Dance event expired" -- maybe these already exist? -- to combat the problem.

But for now, here are some changes that at least make the error pages marginally more useful. Tonally they are somewhat bland but maybe other people have a better grasp of the exact level of cuteness we want to have here.