### PR TITLE
Bought only tables

### DIFF
--- a/brambling/filters.py
+++ b/brambling/filters.py
@@ -112,7 +112,6 @@ class AttendeeFilterSet(django_filters.FilterSet):
 
 
 class OrderFilterSet(FloppyFilterSet):
-    has_cart_items = BoughtItemStatusFilter(status=[BoughtItem.RESERVED, BoughtItem.UNPAID])
     has_purchased_items = BoughtItemStatusFilter(status=BoughtItem.BOUGHT)
     has_refunded_items = BoughtItemStatusFilter(status=BoughtItem.REFUNDED)
 

--- a/brambling/utils/model_tables.py
+++ b/brambling/utils/model_tables.py
@@ -505,8 +505,8 @@ class AttendeeTable(CustomDataTable):
 class OrderTable(CustomDataTable):
     fieldsets = (
         (None,
-         ('code', 'person', 'balance', 'cart_items',
-          'purchased_items', 'refunded_items', 'completed_date')),
+         ('code', 'person', 'balance', 'purchased_items',
+          'refunded_items', 'completed_date')),
     )
     survey_fieldsets = (
         ('Survey',
@@ -624,14 +624,6 @@ class OrderTable(CustomDataTable):
                 queryset = queryset.annotate(
                     balance=Sum('transactions__amount'),
                 )
-            elif field == 'cart_items':
-                queryset = queryset.extra(select={
-                    'cart_items': """
-                        SELECT COUNT(*) FROM brambling_boughtitem WHERE
-                        brambling_boughtitem.order_id = brambling_order.id AND
-                        brambling_boughtitem.status IN ('reserved', 'unpaid')
-                    """,
-                })
             elif field == 'purchased_items':
                 queryset = queryset.extra(select={
                     'purchased_items': """

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -14,14 +14,12 @@ from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.encoding import force_text
 from django.views.generic import (ListView, CreateView, UpdateView,
                                   TemplateView, DetailView, View)
 
 from floppyforms.__future__.models import modelform_factory
 import requests
 
-from brambling.filters import AttendeeFilterSet, OrderFilterSet
 from brambling.forms.organizer import (EventForm, ItemForm, ItemOptionFormSet,
                                        DiscountForm, ItemImageFormSet,
                                        ManualPaymentForm, ManualDiscountForm,
@@ -302,11 +300,16 @@ class EventSummaryView(TemplateView):
 
         fees = (sums['application_fee'] or 0) + (sums['processing_fee'] or 0)
 
+        attendees = Attendee.objects.filter(
+            order__event=self.event,
+            bought_items__status=BoughtItem.BOUGHT,
+        )
+
         context.update({
             'event': self.event,
             'event_admin_nav': get_event_admin_nav(self.event, self.request),
 
-            'attendee_count': Attendee.objects.filter(order__event=self.event).count(),
+            'attendee_count': attendees.count(),
             'itemoptions': itemoptions,
             'discounts': discounts,
 
@@ -321,9 +324,9 @@ class EventSummaryView(TemplateView):
 
         if self.event.collect_housing_data:
             context.update({
-                'attendee_requesting_count': Attendee.objects.filter(order__event=self.event, housing_status=Attendee.NEED).count(),
-                'attendee_arranged_count': Attendee.objects.filter(order__event=self.event, housing_status=Attendee.HAVE).count(),
-                'attendee_home_count': Attendee.objects.filter(order__event=self.event, housing_status=Attendee.HOME).count(),
+                'attendee_requesting_count': attendees.filter(housing_status=Attendee.NEED).count(),
+                'attendee_arranged_count': attendees.filter(housing_status=Attendee.HAVE).count(),
+                'attendee_home_count': attendees.filter(housing_status=Attendee.HOME).count(),
             })
         return context
 

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -799,7 +799,10 @@ class AttendeeFilterView(EventTableView):
 
     def get_queryset(self):
         qs = super(AttendeeFilterView, self).get_queryset()
-        return qs.filter(order__event=self.event).distinct()
+        return qs.filter(
+            order__event=self.event,
+            bought_items__status=BoughtItem.BOUGHT,
+        ).distinct()
 
 
 class OrderFilterView(EventTableView):
@@ -811,7 +814,10 @@ class OrderFilterView(EventTableView):
 
     def get_queryset(self):
         qs = super(OrderFilterView, self).get_queryset()
-        return qs.filter(event=self.event)
+        return qs.annotate(transaction_count=Count('transactions')).filter(
+            event=self.event,
+            transaction_count__gt=0,
+        )
 
 
 class RefundView(View):


### PR DESCRIPTION
This pull request changes the order table to only display orders that have completed transactions (and removes the cart_items field), and changes the attendees table to only display attendees who have bought boughtitems (i.e. exclude folks who are in the process of registering.)

This should address the difficulties that organizers have been having interpreting the tables, by limiting the data to what they actually *need*.