### PR TITLE
Fix file-format bug from Excel 2003. Refs #558

### DIFF
--- a/brambling/utils/model_tables.py
+++ b/brambling/utils/model_tables.py
@@ -409,7 +409,7 @@ class AttendeeTable(CustomDataTable):
     )
 
     label_overrides = {
-        'pk': 'ID',
+        'pk': 'Id',
         'get_full_name': 'Name',
         'housing_nights': 'Housing nights',
         'housing_preferences': 'Housing environment preference',


### PR DESCRIPTION
Apparently Excel doesn't like to open files that begin with "ID", so
let's change it.