### PR TITLE
Add Excel file export. Refs #572

### DIFF
--- a/brambling/static/brambling/sass/modules/_menus.sass
+++ b/brambling/static/brambling/sass/modules/_menus.sass
@@ -1,2 +1,20 @@
 .dropdown-menu > li > a
 	padding: 3px #{$line-height-computed/2}
+
+
+//https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_dropdowns.scss#L65
+.dropdown-menu > li > .btn-link
+	display: block
+	padding: 3px 20px
+	clear: both
+	font-weight: normal
+	line-height: $line-height-base
+	color: $dropdown-link-color
+	white-space: nowrap
+	width: 100%
+	text-align: left
+
+	&:hover, &:focus
+		text-decoration: none
+		color: $dropdown-link-hover-color
+		background-color: $dropdown-link-hover-bg

--- a/brambling/templates/brambling/event/organizer/__table.html
+++ b/brambling/templates/brambling/event/organizer/__table.html
@@ -81,6 +81,10 @@
                         <i class="fa fa-download"></i>
                         <span class='hidden-sm hidden-md'>Download CSV</span>
                     </button>
+                    <button type="submit" class="btn btn-sm btn-default tipped" name="format" value="xlsx" title="Download Excel" data-container="body">
+                        <i class="fa fa-file-excel-o"></i>
+                        <span class='hidden-sm hidden-md'>Download Excel</span>
+                    </button>
                 </div>
                 <div class="modal fade" id="filterModal" tabindex="-1" role="dialog" aria-hidden="true">
                     <div class="modal-dialog">

--- a/brambling/templates/brambling/event/organizer/__table.html
+++ b/brambling/templates/brambling/event/organizer/__table.html
@@ -77,14 +77,21 @@
                         <i class="fa fa-filter"></i>
                         <span class='hidden-sm hidden-md'>Change columns and filters</span>
                     </button>
-                    <button type="submit" class="btn btn-sm btn-default tipped" name="format" value="csv" title="Download CSV" data-container="body">
-                        <i class="fa fa-download"></i>
-                        <span class='hidden-sm hidden-md'>Download CSV</span>
-                    </button>
-                    <button type="submit" class="btn btn-sm btn-default tipped" name="format" value="xlsx" title="Download Excel" data-container="body">
-                        <i class="fa fa-file-excel-o"></i>
-                        <span class='hidden-sm hidden-md'>Download Excel</span>
-                    </button>
+                    <div class="btn-group">
+                        <button class="btn btn-sm btn-default dropdown-toggle tipped" title='Export' type="button" id="exportOptions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
+                            <i class="fa fa-download"></i>
+                            <span class='hidden-sm hidden-md'>Export</span>
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="exportOptions">
+                            <li><button type="submit" class="btn btn-sm btn-link" name="format" value="csv">
+                                Download CSV
+                            </button></li>
+                            <li><button type="submit" class="btn btn-sm btn-link" name="format" value="xlsx">
+                                Download Excel
+                            </button></li>
+                        </ul>
+                    </div>
                 </div>
                 <div class="modal fade" id="filterModal" tabindex="-1" role="dialog" aria-hidden="true">
                     <div class="modal-dialog">

--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -13,6 +13,10 @@
 		<i class="fa fa-download"></i>
 		<span class='hidden-sm hidden-md'>Download CSV</span>
 	  </button>
+	  <button type="submit" class="btn btn-sm btn-default tipped" name="format" value="xlsx" title="Download Excel" data-container="body">
+		  <i class="fa fa-file-excel-o"></i>
+		  <span class='hidden-sm hidden-md'>Download Excel</span>
+	  </button>
 	</form>
 
 	<div class="scroll-x">

--- a/brambling/templates/brambling/event/organizer/finances.html
+++ b/brambling/templates/brambling/event/organizer/finances.html
@@ -9,14 +9,21 @@
 	{% include "brambling/event/_empty_shop_alert.html" %}
 
 	<form>
-	  <button type="submit" class="btn btn-sm btn-default tipped" name="format" value="csv" title="Download CSV" data-container="body">
-		<i class="fa fa-download"></i>
-		<span class='hidden-sm hidden-md'>Download CSV</span>
-	  </button>
-	  <button type="submit" class="btn btn-sm btn-default tipped" name="format" value="xlsx" title="Download Excel" data-container="body">
-		  <i class="fa fa-file-excel-o"></i>
-		  <span class='hidden-sm hidden-md'>Download Excel</span>
-	  </button>
+		<div class="btn-group">
+			<button class="btn btn-sm btn-default dropdown-toggle tipped" title='Export' type="button" id="exportOptions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
+				<i class="fa fa-download"></i>
+				<span class='hidden-sm hidden-md'>Export</span>
+				<span class="caret"></span>
+			</button>
+			<ul class="dropdown-menu" aria-labelledby="exportOptions">
+				<li><button type="submit" class="btn btn-sm btn-link" name="format" value="csv">
+					Download CSV
+				</button></li>
+				<li><button type="submit" class="btn btn-sm btn-link" name="format" value="xlsx">
+					Download Excel
+				</button></li>
+			</ul>
+		</div>
 	</form>
 
 	<div class="scroll-x">

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -737,7 +737,7 @@ class ModelTableView(ListView):
             return response
         elif format_ == 'xlsx':
             table = context['table']
-            all_rows = itertoos.chain((table.header_row(),),table)
+            all_rows = itertools.chain((table.header_row(),), table)
             wb = Workbook(encoding='utf-8')
             ws = wb.active
             ws.title = 'Data'

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -18,6 +18,8 @@ from django.views.generic import (ListView, CreateView, UpdateView,
                                   TemplateView, DetailView, View, DeleteView)
 
 from floppyforms.__future__.models import modelform_factory
+from openpyxl import Workbook
+from openpyxl.writer.excel import save_virtual_workbook
 import requests
 
 from brambling.forms.organizer import (EventForm, ItemForm, ItemOptionFormSet,
@@ -733,6 +735,21 @@ class ModelTableView(ListView):
                                              content_type="text/csv")
             response['Content-Disposition'] = 'attachment; filename="export.csv"'
             return response
+        elif format_ == 'xlsx':
+            table = context['table']
+            all_rows = itertoos.chain((table.header_row(),),table)
+            wb = Workbook(encoding='utf-8')
+            ws = wb.active
+            ws.title = 'Data'
+            for i, row in enumerate(all_rows):
+                for j, cell in enumerate(row):
+                    ws.cell(row=i+1, column=j+1, value=unicode(cell))
+            response = StreamingHttpResponse(
+                save_virtual_workbook(wb),
+                content_type='application/vnd.ms-excel')
+            response['Content-Disposition'] = ('attachment; '
+                                               'filename="export.xlsx"')
+            return response
 
         # Default to the template.
         return super(ModelTableView, self).render_to_response(context, *args, **kwargs)
@@ -1053,6 +1070,21 @@ class FinancesView(ListView):
                                               for row in table.get_rows(include_headers=True)),
                                              content_type="text/csv")
             response['Content-Disposition'] = 'attachment; filename="finances.csv"'
+            return response
+        elif format_ == 'xlsx':
+            context = super(FinancesView, self).get_context_data(**kwargs)
+            table = FinanceTable(self.event, context['transactions'])
+            wb = Workbook(encoding='utf-8')
+            ws = wb.active
+            ws.title = 'Finances'
+            for i, row in enumerate(table.get_rows(include_headers=True)):
+                for j, cell in enumerate(row):
+                    ws.cell(row=i+1, column=j+1, value=unicode(cell.value))
+            response = StreamingHttpResponse(
+                save_virtual_workbook(wb),
+                content_type='application/vnd.ms-excel')
+            response['Content-Disposition'] = ('attachment; '
+                                               'filename="finances.xlsx"')
             return response
 
         # Default to the template.

--- a/test_project/requirements.txt
+++ b/test_project/requirements.txt
@@ -21,6 +21,7 @@ requests==2.5.1
 dwolla==2.0.7
 django-talkback==0.1.0
 djangorestframework==3.1.2
+openpyxl==2.2.6
 
 # our own django-zenaida - @master until we reach a peggable point.
 https://github.com/littleweaver/django-zenaida/tarball/master


### PR DESCRIPTION
Add a button to export the currently exportable tables into .xlsx format.

The UI is about as simple as possible and could possibly be improved, but I am not really familiar enough with the buttons and controls you have going so it might be inconsistent. Having one button for csv and one for excel could pretty easily be replaced with a dropdown or popup or something else to make it fit in better with what you have or just generally be more user-friendly.