### PR TITLE
Corrected invite accept view behavior on an invalid invite code.

### DIFF
--- a/brambling/tests/functional/test_invites.py
+++ b/brambling/tests/functional/test_invites.py
@@ -8,6 +8,7 @@ from brambling.forms.organizer import EventForm
 from brambling.models import Invite
 from brambling.tests.factories import (InviteFactory, EventFactory,
                                        OrganizationFactory, PersonFactory)
+from brambling.views.core import InviteAcceptView
 
 
 class InviteTestCase(TestCase):
@@ -77,3 +78,17 @@ class EventFormTestCase(TestCase):
         form.save()
         self.assertEqual(event.get_invites().count(), 2)
         self.assertEqual(len(mail.outbox), 2)
+
+
+class InviteAcceptViewTestCase(TestCase):
+    def test_context_data__no_invite(self):
+        view = InviteAcceptView()
+        view.invite = None
+        view.content = None
+        view.request = RequestFactory().get('/')
+        context = view.get_context_data()
+        self.assertIsNone(context['invite'])
+        self.assertIsNone(context['content'])
+        self.assertFalse(context['invited_person_exists'])
+        self.assertFalse(context['sender_display'])
+        self.assertFalse(context['invited_person_exists'])

--- a/brambling/views/core.py
+++ b/brambling/views/core.py
@@ -98,12 +98,13 @@ class InviteAcceptView(TemplateView):
         context = super(InviteAcceptView, self).get_context_data(**kwargs)
         if self.invite:
             invited_person_exists = Person.objects.filter(email=self.invite.email).exists()
+            if self.invite.user:
+                sender_display = self.invite.user.get_full_name()
+            elif self.invite.kind == Invite.TRANSFER:
+                sender_display = self.content.order.email
         else:
             invited_person_exists = False
-        if self.invite.user:
-            sender_display = self.invite.user.get_full_name()
-        elif self.invite.kind == Invite.TRANSFER:
-            sender_display = self.content.order.email
+            sender_display = ''
         context.update({
             'invite': self.invite,
             'content': self.content,


### PR DESCRIPTION
Turns out entering an incorrect invite code got you a 500 error. Whoops! This fixes that and adds a test proving so.