### PR TITLE
Made order receipts always use order code URLs.

### DIFF
--- a/brambling/templates/brambling/mail/order_receipt/body.html
+++ b/brambling/templates/brambling/mail/order_receipt/body.html
@@ -2,11 +2,7 @@
 
 {% block content %}
 	{% load zenaida %}
-	{% if order.person %}
-		{% url 'brambling_event_order_summary' event_slug=event.slug organization_slug=event.organization.slug as url %}
-	{% else %}
-		{% url 'brambling_order_code_redirect' event_slug=event.slug organization_slug=event.organization.slug code=order.code as url %}
-	{% endif %}
+	{% url 'brambling_order_code_redirect' event_slug=event.slug organization_slug=event.organization.slug code=order.code as url %}
 	<table class='container'>
 		<tr>
 			<td>

--- a/brambling/templates/brambling/mail/order_receipt/body_inlined.html
+++ b/brambling/templates/brambling/mail/order_receipt/body_inlined.html
@@ -320,11 +320,7 @@ background: #970b0e !important;
             <table class="row header" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: left; width: 100%; position: relative; height: 10px; margin-bottom: 10px; background: #de8e0f; padding: 0px;" bgcolor="#de8e0f"></table>
 
 	{% load zenaida %}
-	{% if order.person %}
-		{% url 'brambling_event_order_summary' event_slug=event.slug organization_slug=event.organization.slug as url %}
-	{% else %}
-		{% url 'brambling_order_code_redirect' event_slug=event.slug organization_slug=event.organization.slug code=order.code as url %}
-	{% endif %}
+	{% url 'brambling_order_code_redirect' event_slug=event.slug organization_slug=event.organization.slug code=order.code as url %}
 	<table class="container" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: inherit; width: 580px; margin: 0 auto; padding: 0;"><tr style="vertical-align: top; text-align: left; padding: 0;" align="left"><td style="word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; border-collapse: collapse !important; vertical-align: top; text-align: left; color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; margin: 0; padding: 0;" align="left" valign="top">
 
 				<table class="row" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: left; width: 100%; position: relative; display: block; padding: 0px;"><tr style="vertical-align: top; text-align: left; padding: 0;" align="left"><td class="wrapper offset-by-three" style="word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; border-collapse: collapse !important; vertical-align: top; text-align: left; position: relative; color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; margin: 0; padding: 10px 20px 0px 150px;" align="left" valign="top">

--- a/brambling/templates/brambling/mail/order_receipt/body_plaintext.txt
+++ b/brambling/templates/brambling/mail/order_receipt/body_plaintext.txt
@@ -24,7 +24,7 @@ Total: {{ total_payments|format_money:event.currency }}
 
 Order #{{ order.code }}{# Transaction date #}
 
-{% if order.person %}{% url 'brambling_event_order_summary' event_slug=event.slug organization_slug=event.organization.slug as url %}{% else %}{% url 'brambling_order_code_redirect' event_slug=event.slug organization_slug=event.organization.slug code=order.code as url%}{% endif %}
+{% url 'brambling_order_code_redirect' event_slug=event.slug organization_slug=event.organization.slug code=order.code as url %}
 View and edit your order at the following URL:
 {{ protocol }}://{{ site.domain }}{{ url }}{% endautoescape %}
 


### PR DESCRIPTION
Resolved #637. From the ticket:

>Right now, we send order code URLs to anonymous orders and flat URLs to non-anonymous orders. As long as folks stay logged in and never change computers, that's fine. But I think we should actually switch to always sending the code version. If they are logged in, it's just another redirect; if not, they can be routed appropriately and redirected back.