### PR TITLE
Prevent text overflow for the cart-expired modal popup.

### DIFF
--- a/brambling/static/brambling/sass/modules/_modals.sass
+++ b/brambling/static/brambling/sass/modules/_modals.sass
@@ -1,2 +1,6 @@
 .modal-title
 	margin-right: $line-height-computed
+
+#countdownCompleteModal
+	a.btn
+		white-space: normal


### PR DESCRIPTION
See #431 for example of problem.

All bootstrap buttons seem to have `white-space: nowrap` on them, so it's possible there are other places on the site where lengthy user input could create overflowing text. This pull request does not fix the general case, just this specific modal.