### PR TITLE
Ensure a white background for banner images.

### DIFF
--- a/brambling/static/brambling/sass/modules/_masthead.sass
+++ b/brambling/static/brambling/sass/modules/_masthead.sass
@@ -41,6 +41,7 @@ $cover-image-padding-vertical: $line-height-computed
     background-size: cover
     background-position: center
     background-repeat: no-repeat
+    background-color: white
     box-shadow: inset 0 0 0 1px rgba(0,0,0,.35)
     border-radius: $border-radius-base $border-radius-base 0 0
     box-sizing: border-box


### PR DESCRIPTION
See #669 

Mostly this is for better compatibility with transparent PNG images.