### PR TITLE
Manually apply word-wrapping to cells with long values.

### DIFF
--- a/brambling/templates/brambling/event/organizer/__table.html
+++ b/brambling/templates/brambling/event/organizer/__table.html
@@ -159,7 +159,9 @@
                                         {{ cell|linebreaksbr }}
                                     </span>
                                 {% else %}
-                                    {{ cell }}
+                                    <span style="white-space:nowrap;">
+                                        {{ cell|wordwrap:60|linebreaksbr }}
+                                    </span>
                                 {% endif %}
                             {% endblock %}
                             {% if not forloop.first %}


### PR DESCRIPTION
What do people think about this as a simple solution to #473? 

The gist of it: if the value of a cell is long, wrap it using django's build-in word wrap filter, then turn off the table's auto-wrapping feature with `white-space: nowrap`, as we are already doing for iterable cells.

This has the advantage of not needing to change the ModelTable code or manually assign widths to specific columns.

The disadvantage, as I see it, is that we may end up having to do the above anyway if we ever want to change to `table-layout: fixed`, which is a CSS property I didn't know much about but does allow for more control over how the table is rendered. But you have to specify the column widths yourself rather than let the browser render them based on the table cell's contents. I have a feeling this process would be annoying, and especially so since these tables we're looking at don't have a fixed number of columns.

So, my hope is that this will tide us over until a full-on clickable & editable grid.