### PR TITLE
Made slug fields more intuitive. Resolved #496.

### DIFF
--- a/brambling/templates/brambling/forms/event.html
+++ b/brambling/templates/brambling/forms/event.html
@@ -8,19 +8,21 @@
 	<div class="panel-body">
 		{% formrow form.name %}
 		{% if form.slug %}
-			{% formrow form.slug %}
+			{% formrow form.slug with prepend="https://dancerfly.com/"|add:organization.slug|add:"/" label="URL" %}
 		{% else %}
 			<div class="form-group">
 				<label class="control-label" for="id_slug">
-				Slug
-				 <span class="required">*</span>
+				URL
 				</label>
-				<input class="form-control" type="text" value="{{ event.slug }}" disabled>
+				<div class='input-group'>
+					<div class='input-group-addon'>https://dancerfly.com/{{ organization.slug }}/</div>
+					<input class="form-control" type="text" value="{{ event.slug }}" disabled>
+				</div>
 				<p class="help-block">{{ form.base_fields.slug.help_text }}</p>
 			</div>
 		{% endif %}
-		{% formrow form.website_url %}
-		{% formrow form.facebook_url %}
+		{% formrow form.website_url with help_text="If your event has its own website, enter the URL here and we'll link to it." %}
+		{% formrow form.facebook_url with help_text="If your event is on Facebook, enter that URL here and we'll link to it." %}
 		{% formrow form.description %}
 		{% formrow form.banner_image with help_text="Images will be scaled and cropped to 940 x 300 pixels.<br />Supported formats: .jpg, .png, .gif" %}
 		{% formrow form.dance_styles %}

--- a/brambling/templates/brambling/organization/profile.html
+++ b/brambling/templates/brambling/organization/profile.html
@@ -16,19 +16,21 @@
 
 			{% formrow form.name %}
 			{% if form.slug %}
-				{% formrow form.slug %}
+				{% formrow form.slug with prepend="https://dancerfly.com/" label="URL" %}
 			{% else %}
 				<div class="form-group">
 					<label class="control-label" for="id_slug">
-					Slug
-					 <span class="required">*</span>
+					URL
 					</label>
-					<input class="form-control" type="text" value="{{ organization.slug }}" disabled>
+					<div class='input-group'>
+						<div class='input-group-addon'>https://dancerfly.com/</div>
+						<input class="form-control" type="text" value="{{ organization.slug }}" disabled>
+					</div>
 					<p class="help-block">{{ form.base_fields.slug.help_text }}</p>
 				</div>
 			{% endif %}
-			{% formrow form.website_url %}
-			{% formrow form.facebook_url %}
+			{% formrow form.website_url with help_text="If your organization has a website, enter the URL here and we'll link to it." %}
+			{% formrow form.facebook_url with help_text="If your organization is on Facebook, enter that URL here and we'll link to it." %}
 			{% formrow form.description %}
 			{% formrow form.banner_image with help_text="Images will be scaled and cropped to 940 x 300 pixels.<br />Supported formats: .jpg, .png, .gif" %}
 			{% formrow form.dance_styles %}


### PR DESCRIPTION
Switched labels for event & org slug fields to "URL" and added a prepend to make clear what the final URL will be. Also added some help text to the org & event website/facebook fields.