### PR TITLE
Hide index / deletion fields

### DIFF
--- a/brambling/templates/brambling/event/organizer/_item_form.html
+++ b/brambling/templates/brambling/event/organizer/_item_form.html
@@ -60,7 +60,7 @@
 
 	{# template for additional item option forms #}
 	<script type="text/html" class="item-option-template">
-		<div class='list-group-item item-option item-option-template'>
+		<div class='list-group-item item-option'>
 			{% form itemoption_formset.empty_form using "brambling/forms/itemoption.html" %}
 		</div>
 	</script>
@@ -75,7 +75,7 @@
 		</div>
 		<div class="panel-footer">
 			<div class='js-formset-add option-add'>
-			</div>{# /.list-group-item #}
+			</div>
 		</div>
 	</div>
 

--- a/brambling/templates/brambling/event/organizer/custom_form_form.html
+++ b/brambling/templates/brambling/event/organizer/custom_form_form.html
@@ -101,8 +101,8 @@
 
 			$('.field-list').formset({
 				prefix: '{{ formset.prefix }}',
-				deleteTrigger: '<a href="#"><i class="fa fa-trash"></i></a>',
-				deleteWrapper: '.actions',
+				deleteTrigger: '<a class="btn btn-link" href="#"><i class="fa fa-fw fa-trash"></i></a>',
+				deleteWrapper: '.js-delete-field',
 				addTrigger: '<a href="#" class="btn btn-default"><i class="fa fa-fw fa-plus"></i> Add a field</a>',
 				addWrapper: '.js-formset-add.field-add',
 				formTemplate: '.field-template',

--- a/brambling/templates/brambling/event/organizer/custom_form_form.html
+++ b/brambling/templates/brambling/event/organizer/custom_form_form.html
@@ -32,48 +32,24 @@
 
 		{# template for additional field forms #}
 		<script type="text/html" class="field-template">
-			<div class='panel panel-default field'>
-				<header class='panel-heading'>
-					<div class='panel-title'>
-						<a href="#{{ formset.empty_form.prefix }}-collapse" data-toggle="collapse">
-							<i class="fa fa-fw fa-chevron-down"></i> Field <span class="count"></span>
-						</a>
-						<div class="actions pull-right"></div>
-					</div>
-				</header>
-				<div class="panel-collapse collapse in" id="{{ formset.empty_form.prefix }}-collapse">
-					<div class='panel-body'>
-						{% form formset.empty_form using "brambling/forms/customformfield.html" %}
-					</div>
-				</div>
+			<div class='list-group-item field'>
+				{% form formset.empty_form using "brambling/forms/customformfield.html" %}
 			</div>
 		</script>
 
-		<div class="field-list panel-group">
-			{% for form in formset.forms %}
-				<div class='panel panel-{% if form.errors %}danger{% else %}default{% endif %} field'>
-					<header class='panel-heading'>
-						<div class='panel-title'>
-							<a href="#{{ form.prefix }}-collapse" title="click to expand" data-toggle="collapse">
-								<i class="fa fa-fw fa-chevron-down"></i> Field <span class="count">{{ forloop.counter }}</span>
-							</a>
-							<div class="actions pull-right"></div>
-						</div>{# /.panel-title #}
-					</header>
-						<div class="panel-collapse collapse{% if form.errors or not form.instance.pk %} in{% endif %}" id="{{ form.prefix }}-collapse">
-							<div class='panel-body'>
-								{% form form using "brambling/forms/customformfield.html" %}
-							</div>
-						</div>
-				</div>
-			{% endfor %}
-		</div>
 
-		<div class='panel panel-default'>
-			<header class='panel-heading'>
-				<div class='panel-title js-formset-add option-add'>
-				</div>{# /.panel-title #}
-			</header>
+		<div class="panel panel-default">
+			<div class='field-list list-group'>
+				{% for form in formset.forms %}
+					<div class='list-group-item list-group-item-{% if form.errors %}danger{% else %}default{% endif %} field'>
+						{% form form using "brambling/forms/customformfield.html" %}
+					</div>
+				{% endfor %}
+			</div>
+			<div class='panel-footer'>
+				<div class='js-formset-add field-add'>
+				</div>
+			</div>
 		</div>
 
 		<button class='btn btn-primary' type="submit">Save</button>
@@ -91,11 +67,11 @@
 
 			var setChoicesDisabled = function(ele) {
 				var $ele = $(ele),
-					$choices = $ele.parent().parent().find('textarea[id$=choices]').parent();
+					$choices = $ele.parent().parent().parent().parent().find('.js-form-choices');
 				if (choice_types.indexOf($ele.val()) !== -1) {
-					$choices.removeClass('hidden');
+					$choices.slideDown();
 				} else {
-					$choices.addClass('hidden');
+					$choices.slideUp();
 				}
 			}
 
@@ -125,10 +101,10 @@
 
 			$('.field-list').formset({
 				prefix: '{{ formset.prefix }}',
-				deleteTrigger: '<a href="#"><i class="fa fa-times"></i></a>',
+				deleteTrigger: '<a href="#"><i class="fa fa-trash"></i></a>',
 				deleteWrapper: '.actions',
-				addTrigger: '<a href="#"><i class="fa fa-fw fa-plus"></i> Add a field</a>',
-				addWrapper: '.js-formset-add.option-add',
+				addTrigger: '<a href="#" class="btn btn-default"><i class="fa fa-fw fa-plus"></i> Add a field</a>',
+				addWrapper: '.js-formset-add.field-add',
 				formTemplate: '.field-template',
 				sortableHandle: '.panel-heading',
 				sortableField: 'index'

--- a/brambling/templates/brambling/event/organizer/custom_form_list.html
+++ b/brambling/templates/brambling/event/organizer/custom_form_list.html
@@ -96,7 +96,7 @@
 						{% endif %}
 					{% endfor %}
 					<a class='list-group-item' href="{% url 'brambling_form_create' event_slug=event.slug organization_slug=event.organization.slug %}?form_type=hosting">
-						<i class='fa fa-fw fa-plus'></i> Add order form
+						<i class='fa fa-fw fa-plus'></i> Add hosting form
 					</a>
 				</div>
 			</div>{# /.panel #}

--- a/brambling/templates/brambling/forms/customformfield.html
+++ b/brambling/templates/brambling/forms/customformfield.html
@@ -4,18 +4,44 @@
 {% formconfig row using "brambling/forms/rows/bootstrap.html" %}
 
 {% block rows %}
-	{% formrow form.name %}
-	{% formrow form.field_type %}
-	{% formrow form.default %}
-	{% formrow form.required %}
-	{% formrow form.help_text %}
-	{% formrow form.choices %}
-	<div class='row js-hide'>
-		<div class='col-md-6'>{% formrow form.index %}</div>
-		<div class='col-md-6'>{% formrow form.DELETE %}</div>
+	<div class='row'>
+		<div class='col-sm-1 hidden-xs'>
+			<span class="js-sortable-handle btn btn-link btn-block a-secret pull-right"><i class="fa fa-bars"></i></span>
+		</div>
+		<div class='margin-trailer-half-xs col-sm-4'>
+			{% formrow form.name using "brambling/forms/rows/no_label.html" with placeholder="Do you snore?" %}
+		</div>
+		<div class='margin-trailer-half-xs col-sm-3'>
+			{% formrow form.field_type using "brambling/forms/rows/no_label.html" %}
+		</div>
+		<div class="col-sm-4">
+			{% formrow form.required %}
+		</div>
+	</div>
+
+	<div class="row">
+		<div class='col-sm-5 col-sm-offset-1'>
+			{% formrow form.default %}
+		</div>
+		<div class='col-sm-6'>
+			{% formrow form.help_text %}
+		</div>
+	</div>
+
+
+	<div class="row js-form-choices" style="display:none;">
+		<div class='col-sm-11 col-sm-offset-1'>
+			{% formrow form.choices %}
+		</div>
 	</div>
 
 	{% for field in form.hidden_fields %}
 		{% formfield field %}
 	{% endfor %}
+	{# The following form fields are controlled with javascript: #}
+	<div class='hide'>
+		{% formrow form.index %}
+		{# Don't render delete box if this is a dynamic form. We'll delete those by removing the DOM element with javascript. #}
+		{% if not "__prefix__" in form.prefix %}{% formrow form.DELETE %}{% endif %}
+	</div>
 {% endblock %}

--- a/brambling/templates/brambling/forms/customformfield.html
+++ b/brambling/templates/brambling/forms/customformfield.html
@@ -6,7 +6,7 @@
 {% block rows %}
 	<div class='row'>
 		<div class='col-sm-1 hidden-xs'>
-			<span class="js-sortable-handle btn btn-link btn-block a-secret pull-right"><i class="fa fa-bars"></i></span>
+			<span class="js-sortable-handle btn btn-link btn-block a-secret pull-right"><i class="fa fa-fw fa-bars"></i></span>
 		</div>
 		<div class='margin-trailer-half-xs col-sm-4'>
 			{% formrow form.name using "brambling/forms/rows/no_label.html" with placeholder="Do you snore?" %}
@@ -14,8 +14,10 @@
 		<div class='margin-trailer-half-xs col-sm-3'>
 			{% formrow form.field_type using "brambling/forms/rows/no_label.html" %}
 		</div>
-		<div class="col-sm-4">
+		<div class="col-sm-3">
 			{% formrow form.required %}
+		</div>
+		<div class='col-sm-1 js-delete-field'>
 		</div>
 	</div>
 


### PR DESCRIPTION
Resolved #544. Turns out the only organizer forms that displayed these fields were the custom form forms. So I cleaned them up a bit and made them match the item option formsets, resolving this issue along the way.