### PR TITLE
Can refund fix

### DIFF
--- a/brambling/models.py
+++ b/brambling/models.py
@@ -1223,8 +1223,10 @@ class Transaction(models.Model):
     def can_refund(self):
         refunded = self.related_transaction_set.filter(
             transaction_type=Transaction.REFUND
-        ).aggregate(refunded=Sum('amount'))['refunded'] or 0
-        return self.amount + refunded > 0
+        ).aggregate(refunded=Sum('amount'))['refunded']
+        # None means there are no refunds, which is relevant
+        # for 0-amount transactions.
+        return refunded is None or self.amount + refunded > 0
 
     def refund(self, amount=None, bought_items=None, issuer=None, dwolla_pin=None):
         if amount is None:

--- a/brambling/tests/functional/test_transaction_model.py
+++ b/brambling/tests/functional/test_transaction_model.py
@@ -1,0 +1,31 @@
+from decimal import Decimal
+
+from django.test import TestCase
+
+from brambling.models import Transaction
+from brambling.tests.factories import (
+    TransactionFactory,
+)
+
+
+class TransactionModelTestCase(TestCase):
+    def test_can_refund(self):
+        txn = TransactionFactory(amount=Decimal("2.00"))
+        self.assertTrue(txn.can_refund())
+
+    def test_can_refund__refunded(self):
+        txn = TransactionFactory(
+            amount=Decimal("2.00"),
+        )
+        txn2 = TransactionFactory(
+            related_transaction=txn,
+            transaction_type=Transaction.REFUND,
+            amount=Decimal("-2.00"),
+        )
+        self.assertFalse(txn.can_refund())
+
+    def test_can_refund__zero_amount(self):
+        txn = TransactionFactory(
+            amount=Decimal("0"),
+        )
+        self.assertTrue(txn.can_refund())

--- a/brambling/tests/functional/test_transaction_model.py
+++ b/brambling/tests/functional/test_transaction_model.py
@@ -29,3 +29,49 @@ class TransactionModelTestCase(TestCase):
             amount=Decimal("0"),
         )
         self.assertTrue(txn.can_refund())
+
+    def test_refund(self):
+        txn = TransactionFactory(amount=Decimal("2.00"))
+        self.assertTrue(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 0)
+        refund = txn.refund()
+        self.assertIsInstance(refund, Transaction)
+        self.assertFalse(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 1)
+
+    def test_refund__refunded(self):
+        txn = TransactionFactory(amount=Decimal("2.00"))
+        self.assertTrue(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 0)
+        refund = txn.refund()
+        self.assertIsInstance(refund, Transaction)
+        self.assertFalse(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 1)
+
+        refund = txn.refund()
+        self.assertIsNone(refund)
+        self.assertFalse(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 1)
+
+    def test_refund__zero_amount(self):
+        txn = TransactionFactory(amount=Decimal("0"))
+        self.assertTrue(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 0)
+        refund = txn.refund()
+        self.assertIsInstance(refund, Transaction)
+        self.assertFalse(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 1)
+
+    def test_refund__zero_amount__refunded(self):
+        txn = TransactionFactory(amount=Decimal("0"))
+        self.assertTrue(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 0)
+        refund = txn.refund()
+        self.assertIsInstance(refund, Transaction)
+        self.assertFalse(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 1)
+
+        refund = txn.refund()
+        self.assertIsNone(refund)
+        self.assertFalse(txn.can_refund())
+        self.assertEqual(txn.related_transaction_set.count(), 1)


### PR DESCRIPTION
Resolved #686 plus a bit. Basically, corrected Transaction refund-related behavior when Transaction's amount is 0 (for example, a fully-comped item). Includes new tests, oh boy!