### PR TITLE
Lengthened dashboard to show all upcoming events, rather than just 5.

### DIFF
--- a/brambling/templates/brambling/dashboard.html
+++ b/brambling/templates/brambling/dashboard.html
@@ -130,7 +130,7 @@
 			{% endif %}
 
 			{% if upcoming_events %}
-				{% for event in upcoming_events|slice:"5" %}
+				{% for event in upcoming_events %}
 					{% cycle 'col1' 'col2' as col silent %}
 					{% if col = 'col1' %}<div class="row">{% endif %}
 					{% include "brambling/_event_list_item.html" %}


### PR DESCRIPTION
I noticed that Rain City Blues can't be found on the dashboard. Turns out it's cause we limit the dashboard to five events because reasons. I don't think we need to do that thing any more.