### PR TITLE
Added form handling of ValueErrors that might be raised while attempting to refresh dwolla information.

### DIFF
--- a/brambling/forms/orders.py
+++ b/brambling/forms/orders.py
@@ -493,7 +493,7 @@ class DwollaPaymentForm(BasePaymentForm):
                         pin=self.cleaned_data['dwolla_pin'],
                         source=self.cleaned_data['source']
                     )
-                except DwollaAPIException as e:
+                except (ValueError, DwollaAPIException) as e:
                     self.add_error(None, getattr(e, 'response', e.message))
 
     def save(self):

--- a/brambling/models.py
+++ b/brambling/models.py
@@ -263,7 +263,7 @@ class Organization(AbstractDwollaModel):
                                      blank=True, null=True)
 
     # This is a secret value set by admins. It will be cached on the event model.
-    default_application_fee_percent = models.DecimalField(max_digits=5, decimal_places=2, default=1.5,
+    default_application_fee_percent = models.DecimalField(max_digits=5, decimal_places=2, default=Decimal(1.5),
                                                           validators=[MaxValueValidator(100), MinValueValidator(0)])
 
     # These are obtained with Stripe Connect via Oauth.
@@ -403,7 +403,7 @@ class Event(models.Model):
                                                     help_text="Minutes before a user's cart expires.")
 
     # This is a secret value set by admins
-    application_fee_percent = models.DecimalField(max_digits=5, decimal_places=2, default=2.5,
+    application_fee_percent = models.DecimalField(max_digits=5, decimal_places=2, default=Decimal('1.5'),
                                                   validators=[MaxValueValidator(100), MinValueValidator(0)])
 
     # Internal tracking fields

--- a/brambling/tests/functional/test_order_forms.py
+++ b/brambling/tests/functional/test_order_forms.py
@@ -1,7 +1,9 @@
 from decimal import Decimal
+from datetime import timedelta
 
 from django.test import TestCase
-from mock import patch, call
+from django.utils import timezone
+from mock import patch
 import stripe
 
 from brambling.forms.orders import (OneTimePaymentForm,
@@ -219,18 +221,22 @@ class PaymentFormTestCase(TestCase):
         self.assertEqual(Decimal(str(txn.processing_fee)), Decimal('0.25'))
 
     @patch('brambling.forms.orders.dwolla_get_sources')
-    @patch('brambling.forms.orders.dwolla_charge', side_effect=ValueError('this is an error'))
-    def test_dwolla_payment_form_handles_valueerror(self, dwolla_charge, dwolla_get_sources):
-        dwolla_charge.return_value = DWOLLA_CHARGE
+    @patch('dwolla.oauth.refresh')
+    def test_dwolla_payment_form_handles_valueerror(self, oauth_refresh, dwolla_get_sources):
+        oauth_refresh.return_value = {
+            'error': 'access_denied',
+            'error_description': 'Arbitrary error code.'
+        }
         dwolla_get_sources.return_value = DWOLLA_SOURCES
         order = OrderFactory()
+        order.event.organization.dwolla_test_access_token_expires = timezone.now() - timedelta(1)
         person = PersonFactory()
         pin = '1234'
         source = 'Balance'
         form = DwollaPaymentForm(order=order, amount=Decimal('42.15'), data={'dwolla_pin': pin, 'source': source}, user=person)
         self.assertTrue(form.is_bound)
         self.assertTrue(form.errors)
-        self.assertEqual(form.errors['__all__'], ['this is an error'])
+        self.assertEqual(form.errors['__all__'], [oauth_refresh.return_value['error_description']])
 
     def test_check_payment_form(self):
         order = OrderFactory()


### PR DESCRIPTION
I am fairly certain that these ValueErrors (caused by expired dwolla refresh tokens) could still crop up if a user's token was expired (rather than the organization's) but this at least plugs the one hole (during validation)