### PR TITLE
Fix unconfirmed check detection in order receipt emails.

### DIFF
--- a/brambling/mail.py
+++ b/brambling/mail.py
@@ -113,6 +113,9 @@ class OrderReceiptMailer(FancyMailer):
             'order': self.transaction.order,
             'person': self.transaction.order.person,
             'event': self.transaction.order.event,
+            'unconfirmed_check_payments': (
+                self.transaction.is_unconfirmed_check()
+            ),
         })
         return context
 

--- a/brambling/tests/functional/test_order_receipt_mailer.py
+++ b/brambling/tests/functional/test_order_receipt_mailer.py
@@ -1,8 +1,10 @@
+from datetime import date, timedelta
 from django.test import TestCase
 
 from zenaida.templatetags.zenaida import format_money
 
 from brambling.mail import OrderReceiptMailer
+from brambling.models import Transaction
 from brambling.tests.factories import (EventFactory, OrderFactory,
                                        TransactionFactory, ItemFactory,
                                        ItemOptionFactory, AttendeeFactory,
@@ -99,3 +101,47 @@ class OrderReceiptMailerForNonUserTestCase(TestCase):
 
     def test_recipients(self):
         self.assertEqual(self.mailer.get_recipients(), [self.order.email])
+
+
+class OrderReceiptMailerWithUnconfirmedCheckPayments(TestCase):
+
+    def setUp(self):
+        event = EventFactory()
+        self.order = OrderFactory(event=event, email='cicero@example.com')
+        transaction = TransactionFactory(event=event, order=self.order,
+                                         amount=130, method=Transaction.CHECK,
+                                         is_confirmed=False)
+        item = ItemFactory(event=event, name='Multipass')
+        item_option1 = ItemOptionFactory(price=100, item=item, name='Gold')
+        item_option2 = ItemOptionFactory(price=60, item=item, name='Silver')
+
+        discount = DiscountFactory(amount=30, discount_type='percent',
+                                   event=event, item_options=[item_option1])
+
+        self.order.add_to_cart(item_option1)
+        self.order.add_to_cart(item_option2)
+        self.order.add_discount(discount)
+        self.order.mark_cart_paid(transaction)
+
+        self.mailer = OrderReceiptMailer(transaction, site='dancerfly.com',
+                                         secure=True)
+        self.event = event
+        #assert event.check_postmark_cutoff, '%r' % event.check_postmark_cutoff
+
+    def test_still_time_to_mail_check(self):
+        self.event.check_postmark_cutoff = date.today() + timedelta(days=5)
+        body = self.mailer.render_body(self.mailer.get_context_data(),
+                                       plaintext=True)
+        self.assertIn("Checks must be postmarked no later than", body)
+
+    def test_past_postmark_cutoff(self):
+        self.event.check_postmark_cutoff = date.today() - timedelta(days=5)
+        body = self.mailer.render_body(self.mailer.get_context_data(),
+                                       plaintext=True)
+        self.assertIn("Payment was due to be postmarked", body)
+
+    def test_postmark_cutoff_today(self):
+        self.event.check_postmark_cutoff = date.today()
+        body = self.mailer.render_body(self.mailer.get_context_data(),
+                                       plaintext=True)
+        self.assertIn("postmarked no later than today", body)


### PR DESCRIPTION
I think as part of #719 the `unconfirmed_check_payments` flag became lost. This brings it back.