### PR TITLE
Excluded transferred items from the taken counts.  Fixed #683

### DIFF
--- a/brambling/api/v1/views.py
+++ b/brambling/api/v1/views.py
@@ -100,7 +100,8 @@ class ItemOptionViewSet(viewsets.ModelViewSet):
             'taken': """
 SELECT COUNT(*) FROM brambling_boughtitem WHERE
 brambling_boughtitem.item_option_id = brambling_itemoption.id AND
-brambling_boughtitem.status != 'refunded'
+brambling_boughtitem.status != 'refunded' AND
+brambling_boughtitem.status != 'transferred'
 """
         })
         return qs

--- a/brambling/tests/functional/test_api.py
+++ b/brambling/tests/functional/test_api.py
@@ -1,14 +1,19 @@
 # encoding: utf-8
 from django.test import TestCase, RequestFactory
 
-from brambling.api.v1.views import AttendeeViewSet, BoughtItemViewSet
+from brambling.api.v1.views import (
+    AttendeeViewSet, BoughtItemViewSet, ItemOptionViewSet
+)
+from brambling.models import Transaction, BoughtItem
 from brambling.tests.factories import (
+    DiscountFactory,
     EventFactory,
     OrderFactory,
     AttendeeFactory,
     PersonFactory,
     ItemFactory,
     ItemOptionFactory,
+    TransactionFactory,
 )
 
 
@@ -80,3 +85,62 @@ class BoughtItemViewSetTestCase(TestCase):
         qs = viewset.get_queryset()
         self.assertEqual(len(qs), 2)
         self.assertEqual(set(qs), set(order.bought_items.all()))
+
+
+class ItemOptionViewSetTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+        event = EventFactory()
+        self.order = OrderFactory(event=event, email='cicero@example.com')
+        self.transaction = TransactionFactory(
+            event=event, order=self.order, amount=130,
+            method=Transaction.CHECK, is_confirmed=False)
+        item = ItemFactory(event=event, name='Multipass')
+        item_option1 = ItemOptionFactory(price=100, item=item, name='Gold')
+        item_option2 = ItemOptionFactory(price=60, item=item, name='Silver')
+
+        discount = DiscountFactory(amount=30, discount_type='percent',
+                                   event=event, item_options=[item_option1])
+
+        self.order.add_to_cart(item_option1)
+        self.order.add_to_cart(item_option2)
+        self.order.add_discount(discount)
+        self.order.mark_cart_paid(self.transaction)
+
+        order2 = OrderFactory(event=event, email='caesar@example.com')
+        order2.add_to_cart(item_option2)
+        transaction2 = TransactionFactory(event=event, order=self.order,
+                                         amount=130, method=Transaction.CHECK,
+                                         is_confirmed=True)
+        order2.mark_cart_paid(transaction2)
+
+
+        self.order3 = OrderFactory(event=event, email='caesar@example.com')
+        self.order3.add_to_cart(item_option1)
+        transaction3 = TransactionFactory(event=event, order=self.order3,
+                                         amount=130, method=Transaction.CHECK,
+                                         is_confirmed=True)
+        self.order3.mark_cart_paid(transaction3)
+
+        self.viewset = ItemOptionViewSet()
+        self.viewset.request = self.factory.get('/')
+        self.viewset.request.user = self.order.person
+
+    def test_taken_counts(self):
+        qs = self.viewset.get_queryset()
+        self.assertEqual([2, 2], [int(p.taken) for p in qs])
+
+    def test_exclude_refunded(self):
+        """should exclude refunded items from the taken count"""
+        self.transaction.refund()
+        qs = self.viewset.get_queryset()
+        self.assertEqual([1, 1], [int(p.taken) for p in qs])
+
+    def test_exclude_transferred(self):
+        """should exclude transferred items from the taken count"""
+        for item in self.order3.bought_items.all():
+            item.status = BoughtItem.TRANSFERRED
+            item.save()
+        qs = self.viewset.get_queryset()
+        self.assertEqual([1, 2], [int(p.taken) for p in qs])


### PR DESCRIPTION
Seems to work okay. Don't have too much to add, here.

Also adds tests for this ItemOption taken endpoint.