### PR TITLE
Subject encoding

### DIFF
--- a/brambling/api/v1/views.py
+++ b/brambling/api/v1/views.py
@@ -164,9 +164,9 @@ class OrderSearchViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = OrderSerializer
     filter_backends = (filters.SearchFilter,)
     permission_classes = [OrderSearchPermission]
-    search_fields = ("code", "person__given_name", "person__middle_name",
-        "person__surname", "attendees__given_name",
-        "attendees__middle_name", "attendees__surname")
+    search_fields = ("code", "person__first_name", "person__middle_name",
+        "person__last_name", "attendees__first_name",
+        "attendees__middle_name", "attendees__last_name")
 
     def get_event(self):
         event_id = self.request.query_params.get('event', None)

--- a/brambling/templates/brambling/mail/invite_editor/subject.txt
+++ b/brambling/templates/brambling/mail/invite_editor/subject.txt
@@ -1,1 +1,1 @@
-{{ invite.user.get_full_name }} has invited you to edit {{ content.name }}
+{{ invite.user.get_full_name|safe }} has invited you to edit {{ content.name|safe }}

--- a/brambling/templates/brambling/mail/invite_event/subject.txt
+++ b/brambling/templates/brambling/mail/invite_event/subject.txt
@@ -1,1 +1,1 @@
-You've been invited to attend {{ content.name }}!
+You've been invited to attend {{ content.name|safe }}!

--- a/brambling/templates/brambling/mail/invite_org_editor/subject.txt
+++ b/brambling/templates/brambling/mail/invite_org_editor/subject.txt
@@ -1,1 +1,1 @@
-{{ invite.user.get_full_name }} has invited you to help manage {{ content.name }}
+{{ invite.user.get_full_name|safe }} has invited you to help manage {{ content.name|safe }}

--- a/brambling/templates/brambling/mail/invite_transfer/subject.txt
+++ b/brambling/templates/brambling/mail/invite_transfer/subject.txt
@@ -1,1 +1,1 @@
-{% if invite.user %}{{ invite.user.get_full_name }}{% else %}{{ content.order.email }}{% endif %} wants to transfer an item to you
+{% if invite.user %}{{ invite.user.get_full_name|safe }}{% else %}{{ content.order.email }}{% endif %} wants to transfer an item to you

--- a/brambling/templates/brambling/mail/order_alert/subject.txt
+++ b/brambling/templates/brambling/mail/order_alert/subject.txt
@@ -1,1 +1,1 @@
-[{{ event.name }}] New purchase by {% if order.person %}{{ order.person.get_full_name }}{% else %}{{ order.email }}{% endif %}
+[{{ event.name|safe }}] New purchase by {% if order.person %}{{ order.person.get_full_name }}{% else %}{{ order.email }}{% endif %}

--- a/brambling/templates/brambling/mail/order_alert/subject.txt
+++ b/brambling/templates/brambling/mail/order_alert/subject.txt
@@ -1,1 +1,1 @@
-[{{ event.name|safe }}] New purchase by {% if order.person %}{{ order.person.get_full_name }}{% else %}{{ order.email }}{% endif %}
+[{{ event.name|safe }}] New purchase by {% if order.person %}{{ order.person.get_full_name|safe }}{% else %}{{ order.email }}{% endif %}

--- a/brambling/templates/brambling/mail/order_receipt/subject.txt
+++ b/brambling/templates/brambling/mail/order_receipt/subject.txt
@@ -1,1 +1,1 @@
-[{{ event.name }}] Receipt for order {{ order.code }}
+[{{ event.name|safe }}] Receipt for order {{ order.code }}

--- a/brambling/tests/functional/test_invites.py
+++ b/brambling/tests/functional/test_invites.py
@@ -20,9 +20,9 @@ class InviteTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} has invited you to edit {}".format(invite.user.get_full_name(), event.name))
     def test_subject__event_editor_apostrophe(self):
-	event= EventFactory(name="James's Test Event")
-	invite=InviteFactory(content_id=event.pk, user=PersonFactory(given_name="Conan",surname="O'Brien"))
-	self.assertEqual(len(mail.outbox), 0)
+        event= EventFactory(name="James's Test Event")
+        invite=InviteFactory(content_id=event.pk, user=PersonFactory(given_name="Conan",surname="O'Brien"))
+        self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} has invited you to edit {}".format(invite.user.get_full_name(),event.name))
@@ -34,36 +34,34 @@ class InviteTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(), event.organization.name))
     def test_subject__organization_editor_apostrophe(self):
-	event= EventFactory(organization=OrganizationFactory(name="Conan's Show"))
-	invite=InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR, user=PersonFactory(given_name="Conan",surname="O'Brien"))
-	self.assertEqual(len(mail.outbox), 0)
+        event= EventFactory(organization=OrganizationFactory(name="Conan's Show"))
+        invite=InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR, user=PersonFactory(given_name="Conan",surname="O'Brien")) 
+        self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(), event.organization.name))
     def test_subject__event(self):
-	event=EventFactory(name="Conan's Show")
-	invite=InviteFactory(content_id=event.pk, kind=Invite.EVENT)
-	content=invite.get_content()
-	self.assertEqual(len(mail.outbox), 0)
+        event=EventFactory(name="Conan's Show")
+        invite=InviteFactory(content_id=event.pk, kind=Invite.EVENT)
+        content=invite.get_content()
+        self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "You've been invited to attend {}!".format(content.name))
     def test_subject__transfer(self):
-	event=EventFactory()
-	self.person = PersonFactory()
+        event=EventFactory()
+        self.person = PersonFactory()
         event = EventFactory()
         self.order = OrderFactory(event=event, person=self.person)
-        transaction = TransactionFactory(event=event, order=self.order,
-                                         amount=130)
+        transaction = TransactionFactory(event=event, order=self.order, amount=130)
         item = ItemFactory(event=event, name='Multipass')
         item_option1 = ItemOptionFactory(price=100, item=item, name='Gold')
-	self.order.add_to_cart(item_option1)
-	boughtitem = self.order.bought_items.all()[0]
-	invite=InviteFactory(content_id=boughtitem.pk, kind=Invite.TRANSFER, user=PersonFactory(given_name="Conan",surname="O'Brien"))
-	invite.send(Site('test.com', 'test.com'), content=invite.get_content())
+        self.order.add_to_cart(item_option1)
+        boughtitem = self.order.bought_items.all()[0]
+        invite=InviteFactory(content_id=boughtitem.pk, kind=Invite.TRANSFER, user=PersonFactory(given_name="Conan",surname="O'Brien"))
+        invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} wants to transfer an item to you".format(invite.user.get_full_name()))
-	
 
 class EventFormTestCase(TestCase):
     def test_clean_invite_attendees__valid(self):

--- a/brambling/tests/functional/test_invites.py
+++ b/brambling/tests/functional/test_invites.py
@@ -6,8 +6,10 @@ from django.test import TestCase, RequestFactory
 
 from brambling.forms.organizer import EventForm
 from brambling.models import Invite
-from brambling.tests.factories import (InviteFactory, EventFactory, OrderFactory, TransactionFactory, ItemFactory,
-                                       OrganizationFactory, PersonFactory, ItemOptionFactory)
+from brambling.tests.factories import (InviteFactory, EventFactory,
+                                       OrderFactory, TransactionFactory,
+                                       ItemFactory, OrganizationFactory,
+                                       PersonFactory, ItemOptionFactory)
 from brambling.views.core import InviteAcceptView
 
 
@@ -19,37 +21,45 @@ class InviteTestCase(TestCase):
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} has invited you to edit {}".format(invite.user.get_full_name(), event.name))
+
     def test_subject__event_editor_apostrophe(self):
-        event= EventFactory(name="James's Test Event")
-        invite=InviteFactory(content_id=event.pk, user=PersonFactory(given_name="Conan",surname="O'Brien"))
+        event = EventFactory(name="James's Test Event")
+        invite = InviteFactory(content_id=event.pk, user=PersonFactory(given_name="Conan",surname="O'Brien"))
         self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, "{} has invited you to edit {}".format(invite.user.get_full_name(),event.name))
+        self.assertEqual(mail.outbox[0].subject, "{} has invited you to edit {}".format(invite.user.get_full_name(), event.name))
+
     def test_subject__organization_editor(self):
         event = EventFactory()
         invite = InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR)
         self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(), event.organization.name))
+        self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(),
+                                                                                               event.organization.name))
+
     def test_subject__organization_editor_apostrophe(self):
-        event= EventFactory(organization=OrganizationFactory(name="Conan's Show"))
-        invite=InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR, user=PersonFactory(given_name="Conan",surname="O'Brien")) 
+        event = EventFactory(organization=OrganizationFactory(name="Conan's Show"))
+        invite = InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR, user=PersonFactory(given_name="Conan",
+                                                                                                                     surname="O'Brien"))
         self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(), event.organization.name))
+        self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(),
+                                                                                               event.organization.name))
+
     def test_subject__event(self):
-        event=EventFactory(name="Conan's Show")
-        invite=InviteFactory(content_id=event.pk, kind=Invite.EVENT)
-        content=invite.get_content()
+        event = EventFactory(name="Conan's Show")
+        invite = InviteFactory(content_id=event.pk, kind=Invite.EVENT)
+        content = invite.get_content()
         self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "You've been invited to attend {}!".format(content.name))
+
     def test_subject__transfer(self):
-        event=EventFactory()
+        event = EventFactory()
         self.person = PersonFactory()
         event = EventFactory()
         self.order = OrderFactory(event=event, person=self.person)
@@ -58,7 +68,8 @@ class InviteTestCase(TestCase):
         item_option1 = ItemOptionFactory(price=100, item=item, name='Gold')
         self.order.add_to_cart(item_option1)
         boughtitem = self.order.bought_items.all()[0]
-        invite=InviteFactory(content_id=boughtitem.pk, kind=Invite.TRANSFER, user=PersonFactory(given_name="Conan",surname="O'Brien"))
+        invite = InviteFactory(content_id=boughtitem.pk, kind=Invite.TRANSFER, user=PersonFactory(given_name="Conan",
+                                                                                                  surname="O'Brien"))
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} wants to transfer an item to you".format(invite.user.get_full_name()))

--- a/brambling/tests/functional/test_invites.py
+++ b/brambling/tests/functional/test_invites.py
@@ -6,8 +6,8 @@ from django.test import TestCase, RequestFactory
 
 from brambling.forms.organizer import EventForm
 from brambling.models import Invite
-from brambling.tests.factories import (InviteFactory, EventFactory,
-                                       OrganizationFactory, PersonFactory)
+from brambling.tests.factories import (InviteFactory, EventFactory, OrderFactory, TransactionFactory, ItemFactory,
+                                       OrganizationFactory, PersonFactory, ItemOptionFactory)
 from brambling.views.core import InviteAcceptView
 
 
@@ -40,7 +40,30 @@ class InviteTestCase(TestCase):
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(), event.organization.name))
-
+    def test_subject__event(self):
+	event=EventFactory(name="Conan's Show")
+	invite=InviteFactory(content_id=event.pk, kind=Invite.EVENT)
+	content=invite.get_content()
+	self.assertEqual(len(mail.outbox), 0)
+        invite.send(Site('test.com', 'test.com'), content=invite.get_content())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "You've been invited to attend {}!".format(content.name))
+    def test_subject__transfer(self):
+	event=EventFactory()
+	self.person = PersonFactory()
+        event = EventFactory()
+        self.order = OrderFactory(event=event, person=self.person)
+        transaction = TransactionFactory(event=event, order=self.order,
+                                         amount=130)
+        item = ItemFactory(event=event, name='Multipass')
+        item_option1 = ItemOptionFactory(price=100, item=item, name='Gold')
+	self.order.add_to_cart(item_option1)
+	boughtitem = self.order.bought_items.all()[0]
+	invite=InviteFactory(content_id=boughtitem.pk, kind=Invite.TRANSFER, user=PersonFactory(given_name="Conan",surname="O'Brien"))
+	invite.send(Site('test.com', 'test.com'), content=invite.get_content())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "{} wants to transfer an item to you".format(invite.user.get_full_name()))
+	
 
 class EventFormTestCase(TestCase):
     def test_clean_invite_attendees__valid(self):

--- a/brambling/tests/functional/test_invites.py
+++ b/brambling/tests/functional/test_invites.py
@@ -24,7 +24,7 @@ class InviteTestCase(TestCase):
 
     def test_subject__event_editor_apostrophe(self):
         event = EventFactory(name="James's Test Event")
-        invite = InviteFactory(content_id=event.pk, user=PersonFactory(given_name="Conan",surname="O'Brien"))
+        invite = InviteFactory(content_id=event.pk, user=PersonFactory(first_name="Conan",last_name="O'Brien"))
         self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
@@ -41,8 +41,8 @@ class InviteTestCase(TestCase):
 
     def test_subject__organization_editor_apostrophe(self):
         event = EventFactory(organization=OrganizationFactory(name="Conan's Show"))
-        invite = InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR, user=PersonFactory(given_name="Conan",
-                                                                                                                     surname="O'Brien"))
+        invite = InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR, user=PersonFactory(first_name="Conan",
+                                                                                                                     last_name="O'Brien"))
         self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
@@ -68,8 +68,8 @@ class InviteTestCase(TestCase):
         item_option1 = ItemOptionFactory(price=100, item=item, name='Gold')
         self.order.add_to_cart(item_option1)
         boughtitem = self.order.bought_items.all()[0]
-        invite = InviteFactory(content_id=boughtitem.pk, kind=Invite.TRANSFER, user=PersonFactory(given_name="Conan",
-                                                                                                  surname="O'Brien"))
+        invite = InviteFactory(content_id=boughtitem.pk, kind=Invite.TRANSFER, user=PersonFactory(first_name="Conan",
+                                                                                                  last_name="O'Brien"))
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} wants to transfer an item to you".format(invite.user.get_full_name()))

--- a/brambling/tests/functional/test_invites.py
+++ b/brambling/tests/functional/test_invites.py
@@ -19,11 +19,24 @@ class InviteTestCase(TestCase):
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} has invited you to edit {}".format(invite.user.get_full_name(), event.name))
-
+    def test_subject__event_editor_apostrophe(self):
+	event= EventFactory(name="James's Test Event")
+	invite=InviteFactory(content_id=event.pk, user=PersonFactory(given_name="Conan",surname="O'Brien"))
+	self.assertEqual(len(mail.outbox), 0)
+        invite.send(Site('test.com', 'test.com'), content=invite.get_content())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "{} has invited you to edit {}".format(invite.user.get_full_name(),event.name))
     def test_subject__organization_editor(self):
         event = EventFactory()
         invite = InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR)
         self.assertEqual(len(mail.outbox), 0)
+        invite.send(Site('test.com', 'test.com'), content=invite.get_content())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(), event.organization.name))
+    def test_subject__organization_editor_apostrophe(self):
+	event= EventFactory(organization=OrganizationFactory(name="Conan's Show"))
+	invite=InviteFactory(content_id=event.organization.pk, kind=Invite.ORGANIZATION_EDITOR, user=PersonFactory(given_name="Conan",surname="O'Brien"))
+	self.assertEqual(len(mail.outbox), 0)
         invite.send(Site('test.com', 'test.com'), content=invite.get_content())
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "{} has invited you to help manage {}".format(invite.user.get_full_name(), event.organization.name))

--- a/brambling/tests/functional/test_mailers.py
+++ b/brambling/tests/functional/test_mailers.py
@@ -73,7 +73,7 @@ class OrderReceiptMailerTestCase(TestCase):
 
     def test_subject_apostrophe(self):
         event = EventFactory(name="Han & Leia's Wedding!")
-        self.person = PersonFactory(given_name="Ma'ayan", surname="Plaut")
+        self.person = PersonFactory(first_name="Ma'ayan", last_name="Plaut")
         self.event_name = event.name
         self.order = OrderFactory(event=event, person=self.person)
         transaction = TransactionFactory(event=event, order=self.order,amount=130)

--- a/brambling/tests/functional/test_mailers.py
+++ b/brambling/tests/functional/test_mailers.py
@@ -30,7 +30,7 @@ class OrderReceiptMailerTestCase(TestCase):
         self.order.mark_cart_paid(transaction)
 
         self.mailer = OrderAlertMailer(transaction, site='dancerfly.com',
-                                         secure=True)
+                                       secure=True)
         self.event_name = event.name
         self.discount_amount = format_money(discount.amount, event.currency)
         self.total_amount = format_money(transaction.amount, event.currency)
@@ -63,26 +63,28 @@ class OrderReceiptMailerTestCase(TestCase):
                             .format(event_name=self.event_name,
                                     person_name=self.person.get_full_name()))
         self.assertEqual(subject, expected_subject)
+
     def test_body_non_inlined_non_plaintext(self):
         body = self.mailer.render_body(self.mailer.get_context_data(),
                                        inlined=False, plaintext=False)
         self.assertIn(self.option1, body)
         self.assertIn(self.option2, body)
         self.assertIn(self.total_amount, body)
+
     def test_subject_apostrophe(self):
-        event=EventFactory(name="Han & Leia's Wedding!")
-        self.person=PersonFactory(given_name="Ma'ayan", surname="Plaut")
-        self.event_name=event.name
+        event = EventFactory(name="Han & Leia's Wedding!")
+        self.person = PersonFactory(given_name="Ma'ayan", surname="Plaut")
+        self.event_name = event.name
         self.order = OrderFactory(event=event, person=self.person)
         transaction = TransactionFactory(event=event, order=self.order,amount=130)
         self.mailer = OrderAlertMailer(transaction, site='dancerfly.com',
-                                         secure=True)
-	subject = self.mailer.render_subject(self.mailer.get_context_data())
-	expected_subject = ('[{event_name}] New purchase by {person_name}'
+                                       secure=True)
+        subject = self.mailer.render_subject(self.mailer.get_context_data())
+        expected_subject = ('[{event_name}] New purchase by {person_name}'
                             .format(event_name=self.event_name,
                                     person_name=self.person.get_full_name()))
-	self.assertEqual(subject, expected_subject)
-	
+        self.assertEqual(subject, expected_subject)
+
 
 class OrderAlertMailerForNonUserOrderTestCase(TestCase):
 

--- a/brambling/tests/functional/test_mailers.py
+++ b/brambling/tests/functional/test_mailers.py
@@ -63,14 +63,26 @@ class OrderReceiptMailerTestCase(TestCase):
                             .format(event_name=self.event_name,
                                     person_name=self.person.get_full_name()))
         self.assertEqual(subject, expected_subject)
-
     def test_body_non_inlined_non_plaintext(self):
         body = self.mailer.render_body(self.mailer.get_context_data(),
                                        inlined=False, plaintext=False)
         self.assertIn(self.option1, body)
         self.assertIn(self.option2, body)
         self.assertIn(self.total_amount, body)
-
+    def test_subject_apostrophe(self):
+	event=EventFactory(name="Han & Leia's Wedding!")
+	self.event_name=event.name
+	self.order = OrderFactory(event=event, person=self.person)
+        transaction = TransactionFactory(event=event, order=self.order,
+                                         amount=130)
+        self.mailer = OrderAlertMailer(transaction, site='dancerfly.com',
+                                         secure=True)
+	subject = self.mailer.render_subject(self.mailer.get_context_data())
+	expected_subject = ('[{event_name}] New purchase by {person_name}'
+                            .format(event_name=self.event_name,
+                                    person_name=self.person.get_full_name()))
+	self.assertEqual(subject, expected_subject)
+	
 
 class OrderAlertMailerForNonUserOrderTestCase(TestCase):
 

--- a/brambling/tests/functional/test_mailers.py
+++ b/brambling/tests/functional/test_mailers.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from zenaida.templatetags.zenaida import format_money
 
-from brambling.mail import (OrderAlertMailer)
+from brambling.mail import OrderAlertMailer
 from brambling.models import Transaction
 from brambling.tests.factories import (EventFactory, OrderFactory,
                                        TransactionFactory, ItemFactory,
@@ -70,12 +70,11 @@ class OrderReceiptMailerTestCase(TestCase):
         self.assertIn(self.option2, body)
         self.assertIn(self.total_amount, body)
     def test_subject_apostrophe(self):
-	event=EventFactory(name="Han & Leia's Wedding!")
-	self.person=PersonFactory(given_name="Ma'ayan", surname="Plaut")
-	self.event_name=event.name
-	self.order = OrderFactory(event=event, person=self.person)
-        transaction = TransactionFactory(event=event, order=self.order,
-                                         amount=130)
+        event=EventFactory(name="Han & Leia's Wedding!")
+        self.person=PersonFactory(given_name="Ma'ayan", surname="Plaut")
+        self.event_name=event.name
+        self.order = OrderFactory(event=event, person=self.person)
+        transaction = TransactionFactory(event=event, order=self.order,amount=130)
         self.mailer = OrderAlertMailer(transaction, site='dancerfly.com',
                                          secure=True)
 	subject = self.mailer.render_subject(self.mailer.get_context_data())

--- a/brambling/tests/functional/test_mailers.py
+++ b/brambling/tests/functional/test_mailers.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from zenaida.templatetags.zenaida import format_money
 
-from brambling.mail import OrderAlertMailer
+from brambling.mail import (OrderAlertMailer, OrderReceiptMailer)
 from brambling.models import Transaction
 from brambling.tests.factories import (EventFactory, OrderFactory,
                                        TransactionFactory, ItemFactory,
@@ -71,17 +71,25 @@ class OrderReceiptMailerTestCase(TestCase):
         self.assertIn(self.total_amount, body)
     def test_subject_apostrophe(self):
 	event=EventFactory(name="Han & Leia's Wedding!")
+	self.person=PersonFactory(given_name="Ma'ayan", surname="Plaut")
 	self.event_name=event.name
 	self.order = OrderFactory(event=event, person=self.person)
         transaction = TransactionFactory(event=event, order=self.order,
                                          amount=130)
         self.mailer = OrderAlertMailer(transaction, site='dancerfly.com',
                                          secure=True)
+	self.receipt= OrderReceiptMailer(transaction, site='dancerfly.com', 
+					 secure=True)
 	subject = self.mailer.render_subject(self.mailer.get_context_data())
+	subject2=self.receipt.render_subject(self.receipt.get_context_data())
 	expected_subject = ('[{event_name}] New purchase by {person_name}'
                             .format(event_name=self.event_name,
                                     person_name=self.person.get_full_name()))
+	expected_subject2 = ('[{event_name}] Receipt for order {order_code}'
+			     .format(event_name=self.event_name,
+				    order_code=self.order.code))
 	self.assertEqual(subject, expected_subject)
+	self.assertEqual(subject2, expected_subject2)
 	
 
 class OrderAlertMailerForNonUserOrderTestCase(TestCase):

--- a/brambling/tests/functional/test_mailers.py
+++ b/brambling/tests/functional/test_mailers.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from zenaida.templatetags.zenaida import format_money
 
-from brambling.mail import (OrderAlertMailer, OrderReceiptMailer)
+from brambling.mail import (OrderAlertMailer)
 from brambling.models import Transaction
 from brambling.tests.factories import (EventFactory, OrderFactory,
                                        TransactionFactory, ItemFactory,
@@ -78,18 +78,11 @@ class OrderReceiptMailerTestCase(TestCase):
                                          amount=130)
         self.mailer = OrderAlertMailer(transaction, site='dancerfly.com',
                                          secure=True)
-	self.receipt= OrderReceiptMailer(transaction, site='dancerfly.com', 
-					 secure=True)
 	subject = self.mailer.render_subject(self.mailer.get_context_data())
-	subject2=self.receipt.render_subject(self.receipt.get_context_data())
 	expected_subject = ('[{event_name}] New purchase by {person_name}'
                             .format(event_name=self.event_name,
                                     person_name=self.person.get_full_name()))
-	expected_subject2 = ('[{event_name}] Receipt for order {order_code}'
-			     .format(event_name=self.event_name,
-				    order_code=self.order.code))
 	self.assertEqual(subject, expected_subject)
-	self.assertEqual(subject2, expected_subject2)
 	
 
 class OrderAlertMailerForNonUserOrderTestCase(TestCase):

--- a/brambling/tests/functional/test_order_receipt_mailer.py
+++ b/brambling/tests/functional/test_order_receipt_mailer.py
@@ -75,8 +75,20 @@ class OrderReceiptMailerTestCase(TestCase):
         self.assertIn(self.item_price, body)
         self.assertIn(self.discount_amount, body)
         self.assertIn(self.total_amount, body)
-
-
+    def test_subject_apostrophe(self):
+	event=EventFactory(name="Han & Leia's Wedding")
+	self.event_name=event.name
+	self.order = OrderFactory(event=event, person=self.person)
+        transaction = TransactionFactory(event=event, order=self.order,
+                                         amount=130)
+	self.mailer = OrderReceiptMailer(transaction, site='dancerfly.com',
+                                         secure=True)
+	subject = self.mailer.render_subject(self.mailer.get_context_data())
+        expected_subject = ('[{event_name}] Receipt for order {order_code}'
+                            .format(event_name=self.event_name,
+                                    order_code=self.order.code))
+        self.assertEqual(subject, expected_subject)
+	
 class OrderReceiptMailerForNonUserTestCase(TestCase):
 
     def setUp(self):

--- a/brambling/tests/functional/test_order_receipt_mailer.py
+++ b/brambling/tests/functional/test_order_receipt_mailer.py
@@ -75,20 +75,21 @@ class OrderReceiptMailerTestCase(TestCase):
         self.assertIn(self.item_price, body)
         self.assertIn(self.discount_amount, body)
         self.assertIn(self.total_amount, body)
+
     def test_subject_apostrophe(self):
-	event=EventFactory(name="Han & Leia's Wedding")
-	self.event_name=event.name
-	self.order = OrderFactory(event=event, person=self.person)
+        event=EventFactory(name="Han & Leia's Wedding")
+        self.event_name=event.name
+        self.order = OrderFactory(event=event, person=self.person)
         transaction = TransactionFactory(event=event, order=self.order,
                                          amount=130)
-	self.mailer = OrderReceiptMailer(transaction, site='dancerfly.com',
+        self.mailer = OrderReceiptMailer(transaction, site='dancerfly.com',
                                          secure=True)
-	subject = self.mailer.render_subject(self.mailer.get_context_data())
+        subject = self.mailer.render_subject(self.mailer.get_context_data())
         expected_subject = ('[{event_name}] Receipt for order {order_code}'
                             .format(event_name=self.event_name,
                                     order_code=self.order.code))
         self.assertEqual(subject, expected_subject)
-	
+
 class OrderReceiptMailerForNonUserTestCase(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixed the subject.txt files in the mail templates to properly display non-HTML characters in email subject lines. 