### PR TITLE
Event banner now redirects to event shop page.

### DIFF
--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -5,7 +5,7 @@
 {% endif %}
 
 <div class="margin-trailer-dbl event-listing">
-	<a href="{{ event.get_absolute_url }}" class="a-secret a-opacity">
+	<a href="{% url 'brambling_event_shop' event_slug=event.slug organization_slug=event.organization.slug %}" class="a-secret a-opacity">
 		<div class="event-listing-image relative"{% if banner_image %} style="background-image: url({{ banner_image }})"{% endif %}>
 			<div class="datecard">
 				<h5 class="datecard-month">{{ event.start_date|date:"M" }}</h5>


### PR DESCRIPTION
Resolves #417 by using a url tag to point to the event shop view's url, instead of using the event.get_absolute_url method. 