### PR TITLE
Prevent charging stripe if amount is negative.

### DIFF
--- a/brambling/forms/orders.py
+++ b/brambling/forms/orders.py
@@ -493,19 +493,17 @@ class DwollaPaymentForm(BasePaymentForm):
 
     def _post_clean(self):
         if 'dwolla_pin' in self.cleaned_data and 'source' in self.cleaned_data:
-            self._charge = None
-            if self.amount > 0:
-                try:
-                    self._charge = dwolla_charge(
-                        account=self.dwolla_account,
-                        amount=float(self.amount),
-                        order=self.order,
-                        event=self.order.event,
-                        pin=self.cleaned_data['dwolla_pin'],
-                        source=self.cleaned_data['source']
-                    )
-                except (ValueError, DwollaAPIException) as e:
-                    self.add_error(None, getattr(e, 'response', e.message))
+            try:
+                self._charge = dwolla_charge(
+                    account=self.dwolla_account,
+                    amount=float(self.amount),
+                    order=self.order,
+                    event=self.order.event,
+                    pin=self.cleaned_data['dwolla_pin'],
+                    source=self.cleaned_data['source']
+                )
+            except (ValueError, DwollaAPIException) as e:
+                self.add_error(None, getattr(e, 'response', e.message))
 
     def save(self):
         return Transaction.from_dwolla_charge(

--- a/brambling/forms/orders.py
+++ b/brambling/forms/orders.py
@@ -415,17 +415,19 @@ class OneTimePaymentForm(BasePaymentForm, AddCardForm):
             'event': self.order.event,
             'order': self.order,
         }
-        try:
-            if self.cleaned_data.get('save_card'):
-                self.card = self.add_card(self.cleaned_data['token'])
-                self._charge = stripe_charge(self.card.id, customer=self.customer, **kwargs)
-            else:
-                self._charge = stripe_charge(self.cleaned_data['token'], **kwargs)
-                self.card = self._charge.card
-        except stripe.error.CardError, e:
-            self.add_error(None, e.message)
-        except stripe.error.APIError, e:
-            self.add_error(None, STRIPE_API_ERROR)
+        self._charge = None
+        if self.amount >= 0:
+            try:
+                if self.cleaned_data.get('save_card'):
+                    self.card = self.add_card(self.cleaned_data['token'])
+                    self._charge = stripe_charge(self.card.id, customer=self.customer, **kwargs)
+                else:
+                    self._charge = stripe_charge(self.cleaned_data['token'], **kwargs)
+                    self.card = self._charge.card
+            except stripe.error.CardError, e:
+                self.add_error(None, e.message)
+            except stripe.error.APIError, e:
+                self.add_error(None, STRIPE_API_ERROR)
 
     def save(self):
         if self.cleaned_data.get('save_card'):

--- a/brambling/templates/brambling/event/order/_payment.html
+++ b/brambling/templates/brambling/event/order/_payment.html
@@ -9,12 +9,12 @@
 	</div>
 </form>
 
-{% if net_balance == 0 %}
-	<form novalidate action="" method="post">
+{% if net_balance <= 0 %}
+	<form novalidate action="" method="post" class='margin-trailer-tiny'>
 		{% csrf_token %}
-		<button type="submit" class="btn btn-primary">Confirm cart purchases</button>
+		<button type="submit" class="btn btn-primary btn-block">Confirm cart purchases</button>
 	</form>
-{% elif net_balance > 0 %}
+{% else %}
 	<div class="panel-group" id="accordion">
 		{% if event.stripe_connected %}
 			{% if choose_card_form and choose_card_form.fields.card.queryset %}

--- a/brambling/tests/functional/test_order_forms.py
+++ b/brambling/tests/functional/test_order_forms.py
@@ -138,59 +138,91 @@ DWOLLA_SOURCES = [
 ]
 
 
-class PaymentFormTestCase(TestCase):
+class OneTimePaymentFormTestCase(TestCase):
+
+    def setUp(self):
+        self.order = OrderFactory()
+        self.event = self.order.event
+        self.person = PersonFactory()
+        self.token = 'FAKE_TOKEN'
+
     @patch('brambling.forms.orders.stripe_charge')
     @patch('brambling.forms.orders.stripe_prep')
-    def test_one_time_payment_form(self, stripe_prep, stripe_charge):
+    def test_successful_charge(self, stripe_prep, stripe_charge):
         stripe_charge.return_value = STRIPE_CHARGE
-        order = OrderFactory()
-        event = order.event
-        person = PersonFactory()
-        token = 'FAKE_TOKEN'
-        form = OneTimePaymentForm(order=order, amount=Decimal('42.15'), data={'token': token}, user=person)
+        form = OneTimePaymentForm(order=self.order, amount=Decimal('42.15'),
+                                  data={'token': self.token}, user=self.person)
         self.assertTrue(form.is_bound)
         self.assertFalse(form.errors)
         stripe_charge.assert_called_once_with(
-            token,
+            self.token,
             amount=Decimal('42.15'),
-            event=event,
-            order=order,
+            event=self.event,
+            order=self.order,
         )
         self.assertEqual(stripe_prep.call_count, 0)
         txn = form.save()
         self.assertIsInstance(txn, Transaction)
-        self.assertEqual(txn.event, event)
+        self.assertEqual(txn.event, self.event)
         self.assertEqual(txn.amount, Decimal('42.15'))
         self.assertEqual(txn.application_fee, Decimal('1.05'))
         self.assertEqual(txn.processing_fee, Decimal('1.52'))
 
+    @patch('brambling.forms.orders.stripe_prep')
+    def test_negative_charge_adds_errors(self, stripe_prep):
+        form = OneTimePaymentForm(order=self.order, amount=Decimal('-1.00'),
+                                  data={'token': self.token}, user=self.person)
+        self.assertTrue(form.is_bound)
+        self.assertTrue(form.errors)
+        self.assertEqual(form.errors['__all__'],
+                         ["Cannot charge an amount less than zero."])
+
+
+class SavedCardPaymentFormTestCase(TestCase):
+
+    def setUp(self):
+        self.person = PersonFactory(stripe_test_customer_id='FAKE_CUSTOMER_ID')
+        self.order = OrderFactory(person=self.person)
+        self.event = self.order.event
+        self.card = CardFactory(is_saved=True)
+        self.person.cards.add(self.card)
+        self.person.save()
+
     @patch('brambling.forms.orders.stripe_charge')
     @patch('brambling.forms.orders.stripe_prep')
-    def test_saved_card_payment_form(self, stripe_prep, stripe_charge):
+    def test_successful_charge(self, stripe_prep, stripe_charge):
         stripe_charge.return_value = STRIPE_CHARGE
-        person = PersonFactory(stripe_test_customer_id='FAKE_CUSTOMER_ID')
-        order = OrderFactory(person=person)
-        event = order.event
-        card = CardFactory(is_saved=True)
-        person.cards.add(card)
-        person.save()
-        form = SavedCardPaymentForm(order, Decimal('42.15'), data={'card': card.pk})
+        form = SavedCardPaymentForm(self.order, Decimal('42.15'),
+                                    data={'card': self.card.pk})
         self.assertTrue(form.is_bound)
         self.assertFalse(form.errors)
         stripe_charge.assert_called_once_with(
-            card.stripe_card_id,
+            self.card.stripe_card_id,
             amount=Decimal('42.15'),
-            event=event,
-            order=order,
+            event=self.event,
+            order=self.order,
             customer='FAKE_CUSTOMER_ID'
         )
         self.assertEqual(stripe_prep.call_count, 0)
         txn = form.save()
         self.assertIsInstance(txn, Transaction)
-        self.assertEqual(txn.event, event)
+        self.assertEqual(txn.event, self.event)
         self.assertEqual(txn.amount, Decimal('42.15'))
         self.assertEqual(txn.application_fee, Decimal('1.05'))
         self.assertEqual(txn.processing_fee, Decimal('1.52'))
+
+    @patch('brambling.forms.orders.stripe_prep')
+    def test_negative_amount_adds_errors(self, stripe_prep):
+        form = SavedCardPaymentForm(self.order, Decimal('-1.00'),
+                                    data={'card': self.card.pk})
+
+        self.assertTrue(form.is_bound)
+        self.assertTrue(form.errors)
+        self.assertEqual(form.errors['__all__'],
+                         ["Cannot charge an amount less than zero."])
+
+
+class DwollaPaymentFormTestCase(TestCase):
 
     @patch('brambling.forms.orders.dwolla_get_sources')
     @patch('brambling.forms.orders.dwolla_charge')
@@ -246,6 +278,9 @@ class PaymentFormTestCase(TestCase):
         self.assertTrue(form.is_bound)
         self.assertTrue(form.errors)
         self.assertEqual(form.errors['__all__'], [oauth_refresh.return_value['error_description']])
+
+
+class CheckPaymentFormTestCase(TestCase):
 
     def test_check_payment_form(self):
         order = OrderFactory()

--- a/brambling/utils/payment.py
+++ b/brambling/utils/payment.py
@@ -17,6 +17,10 @@ constants.debug = settings.DEBUG
 DWOLLA_SCOPES = "send|accountinfofull|funding|transactions"
 
 
+class InvalidAmountException(ValueError):
+    """The amount to be charged must be zero or positive."""
+
+
 def get_fee(event, amount):
     fee = event.application_fee_percent / 100 * Decimal(str(amount))
     return fee.quantize(Decimal('0.01'), rounding=ROUND_DOWN)
@@ -182,8 +186,8 @@ def stripe_prep(api_type):
 
 
 def stripe_charge(card_or_token, amount, order, event, customer=None):
-    if amount <= 0:
-        return None
+    if amount < 0:
+        raise InvalidAmountException('Cannot charge an amount less than zero.')
     stripe_prep(event.api_type)
     if event.api_type == LIVE:
         access_token = event.organization.stripe_access_token

--- a/brambling/utils/payment.py
+++ b/brambling/utils/payment.py
@@ -94,6 +94,8 @@ def dwolla_charge(account, amount, order, event, pin, source):
     """
     Charges to dwolla and returns a charge transaction.
     """
+    if amount < 0:
+        raise InvalidAmountException('Cannot charge an amount less than zero.')
     if account.api_type != event.api_type:
         raise ValueError("Account and event API types do not match.")
     org_account = event.organization.get_dwolla_account(event.api_type)

--- a/brambling/views/orders.py
+++ b/brambling/views/orders.py
@@ -694,10 +694,10 @@ class SummaryView(OrderMixin, WorkflowMixin, TemplateView):
     def post(self, request, *args, **kwargs):
         self.summary_data = self.order.get_summary_data()
         self.net_balance = self.summary_data['net_balance']
-        if self.net_balance == 0:
+        if self.net_balance <= 0:
             valid = True
             payment = Transaction.objects.create(
-                amount=0,
+                amount=self.net_balance,
                 method=Transaction.NONE,
                 transaction_type=Transaction.PURCHASE,
                 is_confirmed=True,


### PR DESCRIPTION
Fixes error we saw on production site: `'NoneType' object has no attribute 'card'`

Context:
`/var/www/env/src/django-brambling/brambling/forms/orders.py in _post_clean`

```
self <brambling.forms.orders.OneTimePaymentForm object at 0x7fa7bf6e2990>

kwargs
{'amount': Decimal('-94.00'),
 'event': <Event: {{name removed}}>,
 'order': <Order: Order object>}
```

Other notes:

 * If the amount is negative, we can't charge and the form code
   assumes that you can charge.
 * Setting `self._charge` to `None` by default to mimic the Dwolla
   form functionality.  Not totally sure if needed.