### PR TITLE
Fix discount form on payment page

### DIFF
--- a/brambling/templates/brambling/event/order/_payment.html
+++ b/brambling/templates/brambling/event/order/_payment.html
@@ -1,6 +1,6 @@
 {% load floppyforms zenaida %}
 
-<form class='margin-trailer-tiny'>
+<form id='discountForm' class='margin-trailer-tiny'>
 	<div class='input-group input-group-lg'>
 		<input id='discountCode' class='form-control' placeholder='Discount code' autocomplete='off'>
 		<span class='input-group-btn'>


### PR DESCRIPTION
Fixes #762 -- the form was lacking the proper `id` that the discount javascript was looking for.