### PR TITLE
Make Order forms always display, regardless of "collect survey data"

### DIFF
--- a/brambling/migrations/0053_auto_20160425_2258.py
+++ b/brambling/migrations/0053_auto_20160425_2258.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('brambling', '0052_auto_20160318_0712'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='customform',
+            name='form_type',
+            field=models.CharField(max_length=8, choices=[('attendee', 'Attendee'), ('order', 'Order'), ('housing', 'Housing'), ('hosting', 'Hosting')]),
+        ),
+    ]

--- a/brambling/models.py
+++ b/brambling/models.py
@@ -1790,8 +1790,7 @@ class CustomForm(models.Model):
         (HOUSING, _('Housing')),
         (HOSTING, _('Hosting')),
     )
-    form_type = models.CharField(max_length=8, choices=FORM_TYPE_CHOICES,
-                                 help_text='Order forms will only display if "collect survey data" is checked in your event settings')
+    form_type = models.CharField(max_length=8, choices=FORM_TYPE_CHOICES)
     event = models.ForeignKey(Event, related_name="forms")
     # TODO: Add fk/m2m to BoughtItem to limit people the form is
     # displayed to.

--- a/brambling/templates/brambling/event/order/survey.html
+++ b/brambling/templates/brambling/event/order/survey.html
@@ -50,6 +50,7 @@
 			{% form form using %}
 				{% formconfig row using "brambling/forms/rows/bootstrap.html" %}
 
+				{% if event.collect_survey_data %}
 				{% formrow form.heard_through %}
 
 				<div id="heardOtherField" class="collapse{% if form.instance.heard_through %} in{% endif %}">
@@ -67,6 +68,7 @@
 					</div>
 					{% formrow form.send_flyers_country %}
 				</div>
+				{% endif %}
 
 				{% for field in form.custom_fields %}
 					{% formrow field %}

--- a/brambling/views/orders.py
+++ b/brambling/views/orders.py
@@ -19,7 +19,7 @@ from brambling.forms.orders import (SavedCardPaymentForm, OneTimePaymentForm,
 from brambling.mail import OrderReceiptMailer, OrderAlertMailer
 from brambling.models import (BoughtItem, ItemOption, Discount, Order,
                               Attendee, EventHousing, Event, Transaction,
-                              Person, SavedAttendee)
+                              Person, SavedAttendee, CustomForm)
 from brambling.utils.invites import TransferInvite
 from brambling.utils.payment import dwolla_oauth_url
 from brambling.views.utils import (get_event_admin_nav, ajax_required,
@@ -151,7 +151,8 @@ class SurveyStep(OrderStep):
 
     @classmethod
     def include_in(cls, workflow):
-        return workflow.event.collect_survey_data
+        return (workflow.event.collect_survey_data or
+                workflow.event.forms.filter(form_type=CustomForm.ORDER).exists())
 
     def _is_completed(self):
         if not self.workflow.order:


### PR DESCRIPTION
Fixes issue raised in feedback.

The collect survey data checkbox now explicitly controls only the
built-in questions (how did you hear about it, distribution
promotional materials).  If there is an order form, there will always
be a survey step with that form on it.