### PR TITLE
Fix discount form permissions

### DIFF
--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -925,6 +925,7 @@ def discount_form(request, *args, **kwargs):
         'discount_form': form,
         'cart': None,
         'event_admin_nav': get_event_admin_nav(event, request),
+        'event_permissions': request.user.get_all_permissions(event),
     }
     return render(request, 'brambling/event/organizer/discount_form.html', context)
 


### PR DESCRIPTION
This pull request adds the permission information for the current user into the `discount_form` view's context. This fixes bug #784 where organizers could not create or update discounts using that form.