### PR TITLE
Manage event dropdown

### DIFF
--- a/brambling/filters.py
+++ b/brambling/filters.py
@@ -124,5 +124,7 @@ class OrderFilterSet(FloppyFilterSet):
             ('code', 'Code'),
             ('-code', 'Code (descending)'),
         ]
+
+
 # Workaround for https://github.com/gregmuellegger/django-floppyforms/issues/145
 forms.MultipleChoiceField.hidden_widget = forms.MultipleHiddenInput

--- a/brambling/static/brambling/sass/modules/_event-listing.sass
+++ b/brambling/static/brambling/sass/modules/_event-listing.sass
@@ -32,3 +32,9 @@
 	margin: 0
 	line-height: 1em
 	font-size: floor(($font-size-base * 1.5))
+
+.event-listing-image
+	& > .relative-right
+		right: 6px
+	& > .relative-top
+		top: 6px

--- a/brambling/static/brambling/sass/modules/_event-listing.sass
+++ b/brambling/static/brambling/sass/modules/_event-listing.sass
@@ -33,7 +33,7 @@
 	line-height: 1em
 	font-size: floor(($font-size-base * 1.5))
 
-.event-listing-image
+.event-listing
 	& > .relative-right
 		right: 6px
 	& > .relative-top

--- a/brambling/static/brambling/sass/styles.sass
+++ b/brambling/static/brambling/sass/styles.sass
@@ -16,6 +16,7 @@
 @import modules/mixins
 @import modules/base
 @import modules/text
+@import modules/layout
 //
 @import modules/carousel
 @import modules/colors
@@ -24,7 +25,6 @@
 @import modules/forms
 @import modules/headings
 @import modules/images
-@import modules/layout
 @import modules/list-group
 @import modules/marketing
 @import modules/masthead

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -61,40 +61,7 @@
 					Manage Event
 					<span class="caret"></span>
 				</a>
-				<ul class="dropdown-menu" aria-labelledby="manageEvent">
-					<li>
-						<a href="{% url 'brambling_event_summary' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Event Summary</a>
-					</li>
-					<li>
-						<a href="{% url 'brambling_event_basic' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Basic Information</a>
-					</li>
-					<li>
-						<a href="{% url 'brambling_event_permissions' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Team and Permissions</a>
-					</li>
-					<li role="separator" class="divider"></li>
-					<li>
-						<a href="{% url 'brambling_event_registration' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Registration Settings</a>
-					</li>
-					<li>
-						<a href="{% url 'brambling_item_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Items</a>
-					</li>
-					<li>
-						<a href="{% url 'brambling_form_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Forms</a>
-					</li>
-					<li>
-						<a href="{% url 'brambling_discount_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Discounts</a>
-					</li>
-					<li role="separator" class="divider"></li>
-					<li>
-						<a href="{% url 'brambling_event_attendees' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Attendee Data</a>
-					</li>
-					<li>
-						<a href="{% url 'brambling_event_orders' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Order Data</a>
-					</li>
-					<li>
-						<a href="{% url 'brambling_event_finances' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Finance Data</a>
-					</li>
-				</ul>
+				{% include "brambling/_event_manage_dropdown.html" %}
 			</div>
 		{% endif %}
 		{% if event.website_url %}

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -55,10 +55,47 @@
 				</a>
 			{% endif %}
 		{% if is_admin %}
-			<a href="{% url 'brambling_event_summary' event_slug=event.slug organization_slug=event.organization.slug %}" class="margin-trailer-half btn btn-default">
-				<i class="fa fa-cog"></i>
-				Manage Event
-			</a>
+			<div class="btn-group">
+				<a class="margin-trailer-half btn btn-default dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
+					<i class="fa fa-cog"></i>
+					Manage Event
+					<span class="caret"></span>
+				</a>
+				<ul class="dropdown-menu" aria-labelledby="manageEvent">
+					<li>
+						<a href="{% url 'brambling_event_summary' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Event Summary</a>
+					</li>
+					<li>
+						<a href="{% url 'brambling_event_basic' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Basic Information</a>
+					</li>
+					<li>
+						<a href="{% url 'brambling_event_permissions' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Team and Permissions</a>
+					</li>
+					<li role="separator" class="divider"></li>
+					<li>
+						<a href="{% url 'brambling_event_registration' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Registration Settings</a>
+					</li>
+					<li>
+						<a href="{% url 'brambling_item_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Items</a>
+					</li>
+					<li>
+						<a href="{% url 'brambling_form_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Forms</a>
+					</li>
+					<li>
+						<a href="{% url 'brambling_discount_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Discounts</a>
+					</li>
+					<li role="separator" class="divider"></li>
+					<li>
+						<a href="{% url 'brambling_event_attendees' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Attendee Data</a>
+					</li>
+					<li>
+						<a href="{% url 'brambling_event_orders' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Order Data</a>
+					</li>
+					<li>
+						<a href="{% url 'brambling_event_finances' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Finance Data</a>
+					</li>
+				</ul>
+			</div>
 		{% endif %}
 		{% if event.website_url %}
 			<a target="_blank" href="{{ event.website_url }}" class="margin-trailer-half btn btn-default-dark">

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -11,6 +11,18 @@
 				<h5 class="datecard-month">{{ event.start_date|date:"M" }}</h5>
 				<p class="datecard-day">{{ event.start_date|date:"j" }}</p>
 			</div>
+
+			{% if is_admin %}
+				<div class="btn-group relative-right relative-top">
+					<a class="btn btn-default dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
+						<i class="fa fa-cog"></i>
+						Manage
+						<span class="caret"></span>
+					</a>
+					{% include "brambling/_event_manage_dropdown.html" with classes="dropdown-menu-right" %}
+				</div>
+			{% endif %}
+
 		</div>
 	</a>
 	<h3>

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -4,27 +4,27 @@
 	{% adjust event.banner_image 'fill' width=940 height=300 as banner_image %}
 {% endif %}
 
-<div class="margin-trailer-dbl event-listing">
+<div class="margin-trailer-dbl event-listing relative">
 	<a href="{% url 'brambling_event_shop' event_slug=event.slug organization_slug=event.organization.slug %}" class="a-secret a-opacity">
-		<div class="event-listing-image relative"{% if banner_image %} style="background-image: url({{ banner_image }})"{% endif %}>
+		<div class="event-listing-image"{% if banner_image %} style="background-image: url({{ banner_image }})"{% endif %}>
 			<div class="datecard">
 				<h5 class="datecard-month">{{ event.start_date|date:"M" }}</h5>
 				<p class="datecard-day">{{ event.start_date|date:"j" }}</p>
 			</div>
 
-			{% if is_admin %}
-				<div class="btn-group relative-right relative-top">
-					<a class="btn btn-default dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
-						<i class="fa fa-cog"></i>
-						Manage
-						<span class="caret"></span>
-					</a>
-					{% include "brambling/_event_manage_dropdown.html" with classes="dropdown-menu-right" %}
-				</div>
-			{% endif %}
 
 		</div>
 	</a>
+	{% if is_admin %}
+	<div class="btn-group relative-right relative-top">
+		<a class="btn btn-default dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
+			<i class="fa fa-cog"></i>
+			Manage
+			<span class="caret"></span>
+		</a>
+		{% include "brambling/_event_manage_dropdown.html" with classes="dropdown-menu-right" %}
+	</div>
+	{% endif %}
 	<h3>
 		{{ event.name }}
 		{% if is_admin and not event.is_published %}

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -66,16 +66,6 @@
 					<i class="fa fa-ticket"></i> Register <span class="hidden-xs hidden-sm hidden-md">for <strong>{{ event.name }}</strong>!</span>
 				</a>
 			{% endif %}
-		{% if is_admin %}
-			<div class="btn-group">
-				<a class="margin-trailer-half btn btn-default dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
-					<i class="fa fa-cog"></i>
-					Manage Event
-					<span class="caret"></span>
-				</a>
-				{% include "brambling/_event_manage_dropdown.html" %}
-			</div>
-		{% endif %}
 		{% if event.website_url %}
 			<a target="_blank" href="{{ event.website_url }}" class="margin-trailer-half btn btn-default-dark">
 				<i class="fa fa-fw fa-globe"></i>

--- a/brambling/templates/brambling/_event_manage_dropdown.html
+++ b/brambling/templates/brambling/_event_manage_dropdown.html
@@ -1,0 +1,34 @@
+<ul class="dropdown-menu {{ classes }}" aria-labelledby="manageEvent">
+	<li>
+		<a href="{% url 'brambling_event_summary' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Event Summary</a>
+	</li>
+	<li>
+		<a href="{% url 'brambling_event_basic' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Basic Information</a>
+	</li>
+	<li>
+		<a href="{% url 'brambling_event_permissions' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Team and Permissions</a>
+	</li>
+	<li role="separator" class="divider"></li>
+	<li>
+		<a href="{% url 'brambling_event_registration' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Registration Settings</a>
+	</li>
+	<li>
+		<a href="{% url 'brambling_item_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Items</a>
+	</li>
+	<li>
+		<a href="{% url 'brambling_form_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Forms</a>
+	</li>
+	<li>
+		<a href="{% url 'brambling_discount_list' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Discounts</a>
+	</li>
+	<li role="separator" class="divider"></li>
+	<li>
+		<a href="{% url 'brambling_event_attendees' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Attendee Data</a>
+	</li>
+	<li>
+		<a href="{% url 'brambling_event_orders' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Order Data</a>
+	</li>
+	<li>
+		<a href="{% url 'brambling_event_finances' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Finance Data</a>
+	</li>
+</ul>

--- a/brambling/templates/brambling/_event_manage_dropdown.html
+++ b/brambling/templates/brambling/_event_manage_dropdown.html
@@ -8,6 +8,9 @@
 	<li>
 		<a href="{% url 'brambling_event_permissions' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Team and Permissions</a>
 	</li>
+	<li>
+		<a href="{% url 'brambling_event_design' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Design</a>
+	</li>
 	<li role="separator" class="divider"></li>
 	<li>
 		<a href="{% url 'brambling_event_registration' event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-link">Registration Settings</a>

--- a/brambling/templates/brambling/event/order/_masthead.html
+++ b/brambling/templates/brambling/event/order/_masthead.html
@@ -28,9 +28,14 @@
 			</div>{# /.relative-bottom.relative-left.relative-right #}
 
 			{% if event_admin_nav %}
-				<a href="{% url "brambling_event_summary" event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-primary-light relative-top relative-right">
-					<i class="fa fa-cog"></i> Manage Event
-				</a>
+				<div class="btn-group relative-top relative-right">
+					<a href="{% url "brambling_event_summary" event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-primary-light dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
+						<i class="fa fa-cog"></i>
+						Manage Event
+						<span class="caret"></span>
+					</a>
+					{% include "brambling/_event_manage_dropdown.html" with classes="dropdown-menu-right" %}
+				</div>
 			{% endif %}
 		</div>{# /.relative #}
 	</div>{# /.masthead-cover-image #}

--- a/brambling/templates/brambling/event/order/_masthead.html
+++ b/brambling/templates/brambling/event/order/_masthead.html
@@ -31,7 +31,7 @@
 				<div class="btn-group relative-top relative-right">
 					<a href="{% url "brambling_event_summary" event_slug=event.slug organization_slug=event.organization.slug %}" class="btn btn-primary-light dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
 						<i class="fa fa-cog"></i>
-						Manage Event
+						Manage
 						<span class="caret"></span>
 					</a>
 					{% include "brambling/_event_manage_dropdown.html" with classes="dropdown-menu-right" %}


### PR DESCRIPTION
This pull request adds: a super-basic dropdown with shortcut links to the different event management areas. Seems like it gets the job done, but could potentially use some bolt-tightening if there's a better way to structure the markup, responsiveize it, give it some visual flair, and so on.

Resolves #327.
