### PR TITLE
Link to Email Attendees

### DIFF
--- a/brambling/templates/brambling/event/organizer/summary.html
+++ b/brambling/templates/brambling/event/organizer/summary.html
@@ -157,6 +157,18 @@
 					</a>
 				</div>
 			</div>
+			<div class='panel panel-default'>
+				<div class='panel-heading'>
+					<h4 class='panel-title'>
+						Communication
+					</h4>
+				</div>
+				<div class="panel-body">
+					<p>Use the link below to create an email to all the attendees for this event.  The emails will be in the BCC field.  It will open in your computer's email program, though the resulting list can be copied and pasted as desired.</p>
+
+					<a class="btn btn-default" href="mailto:?bcc={{ attendee_emails }}">Send email to attendees</a>
+				</div>
+			</div>
 		</div>
 	</div>
 {% endblock %}

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -413,6 +413,7 @@ class EventSummaryView(TemplateView):
             'event_permissions': self.request.user.get_all_permissions(self.event),
 
             'attendee_count': attendees.count(),
+            'attendee_emails': ','.join(a.email for a in attendees),
             'itemoptions': itemoptions,
             'discounts': discounts,
 


### PR DESCRIPTION
See #244 for motivation.

New features: a Communication panel on the event summary page that has some explanatory text and a button `mailto` link with all of the attendee emails in the BCC field.

![screen shot 2016-03-14 at 15 24 41](https://cloud.githubusercontent.com/assets/561931/13757020/f9cf0242-e9f8-11e5-8e12-0a0fa8356a43.png)

Discussion: I like the idea of a dedicated area for communication tools, potentially this could be expanded later to include actual email sending functions (as noted in #244) but right now just a link seems fine. This could also be on its own "tab" with a link on the side menu, but I thought that might be too much for just a single link. This, as well as other potential "homes" for the link are up for debate.

Also the documentation could use a once-over from someone.