### PR TITLE
Remove obsolete field from event admin.

### DIFF
--- a/brambling/admin/admin.py
+++ b/brambling/admin/admin.py
@@ -184,7 +184,7 @@ class EventAdmin(admin.ModelAdmin):
         }),
         ("Permissions", {
             'classes': ('grp-collapse grp-closed',),
-            'fields': ("organization", "additional_editors"),
+            'fields': ("organization",),
         }),
         ("Dancerfly Internal", {
             'classes': ('grp-collapse grp-closed',),


### PR DESCRIPTION
This pull request removes the field `additional_editors` from the event admin page. That field was removed from the `Event` model when we revamped the permission system.