### PR TITLE
Implement staging and production tiers for fabric.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -2,7 +2,7 @@ import os
 
 from fabric.api import task, run, sudo, cd, env
 from fabric.contrib.files import exists
-from fabric.operations import local, put
+from fabric.operations import local, put, require
 
 
 env.use_ssh_config = True
@@ -13,13 +13,41 @@ DEFAULT_BRANCH = 'master'
 CURRENT_DIR = os.path.dirname(__file__)
 
 
+TIERS = {
+    'production': {
+        'hosts': ['root@104.131.92.59'],
+    },
+    'staging': {
+        'hosts': ['root@162.243.226.226'],
+    },
+}
+
+
+def tier_set(tier_name='staging'):
+    env.tier = tier_name
+    for option, value in TIERS[env.tier].items():
+        setattr(env, option, value)
+
+
+@task
+def production():
+    tier_set('production')
+
+
+@task
+def staging():
+    tier_set('staging')
+
+
 @task
 def install_salt():
+    require('tier', provided_by=(staging,production))
     run("curl -L https://bootstrap.saltstack.com | sudo sh -s -- -P git a6c0907")
 
 
 @task
 def sync_pillar(branch_or_commit='master'):
+    require('tier', provided_by=(staging,production))
     if not os.path.exists(os.path.join(CURRENT_DIR, 'pillar')):
         local("git clone {} pillar".format(PILLAR_REPO_URL))
     if not exists('/root/.ssh/id_rsa'):
@@ -37,6 +65,7 @@ def sync_pillar(branch_or_commit='master'):
 
 @task
 def deploy_code(branch_or_commit=DEFAULT_BRANCH):
+    require('tier', provided_by=(staging,production))
     if not exists('/var/www/'):
         sudo('mkdir /var/www')
     with cd("/var/www"):
@@ -56,11 +85,13 @@ def deploy_code(branch_or_commit=DEFAULT_BRANCH):
 
 @task
 def salt_call():
+    require('tier', provided_by=(staging,production))
     sudo("salt-call --local state.highstate")
 
 
 @task
 def deploy(branch_or_commit=DEFAULT_BRANCH):
+    require('tier', provided_by=(staging,production))
     if not run('which salt-call', quiet=True):
         install_salt()
     sync_pillar()
@@ -72,10 +103,12 @@ def deploy(branch_or_commit=DEFAULT_BRANCH):
 
 @task
 def manage(command):
+    require('tier', provided_by=(staging,production))
     full_command = "/bin/bash -l -c 'source /var/www/env/bin/activate && python /var/www/project/manage.py {0}'".format(command)
     sudo(full_command, user="webproject")
 
 
 @task
 def restart_gunicorn():
+    require('tier', provided_by=(staging,production))
     sudo('circusctl restart gunicorn')

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,8 +24,8 @@ TIERS = {
     },
 }
 
-def forbid_in_tiers(*forbidden_tiers):
 
+def forbid_in_tiers(*forbidden_tiers):
     def func_wrapper(func):
         @wraps(func)
         def returned_wrapper(*args, **kwargs):

--- a/fabfile.py
+++ b/fabfile.py
@@ -41,13 +41,13 @@ def staging():
 
 @task
 def install_salt():
-    require('tier', provided_by=(staging,production))
+    require('tier', provided_by=(staging, production))
     run("curl -L https://bootstrap.saltstack.com | sudo sh -s -- -P git a6c0907")
 
 
 @task
 def sync_pillar(branch_or_commit='master'):
-    require('tier', provided_by=(staging,production))
+    require('tier', provided_by=(staging, production))
     if not os.path.exists(os.path.join(CURRENT_DIR, 'pillar')):
         local("git clone {} pillar".format(PILLAR_REPO_URL))
     if not exists('/root/.ssh/id_rsa'):
@@ -65,7 +65,7 @@ def sync_pillar(branch_or_commit='master'):
 
 @task
 def deploy_code(branch_or_commit=DEFAULT_BRANCH):
-    require('tier', provided_by=(staging,production))
+    require('tier', provided_by=(staging, production))
     if not exists('/var/www/'):
         sudo('mkdir /var/www')
     with cd("/var/www"):
@@ -85,13 +85,13 @@ def deploy_code(branch_or_commit=DEFAULT_BRANCH):
 
 @task
 def salt_call():
-    require('tier', provided_by=(staging,production))
+    require('tier', provided_by=(staging, production))
     sudo("salt-call --local state.highstate")
 
 
 @task
 def deploy(branch_or_commit=DEFAULT_BRANCH):
-    require('tier', provided_by=(staging,production))
+    require('tier', provided_by=(staging, production))
     if not run('which salt-call', quiet=True):
         install_salt()
     sync_pillar()
@@ -103,12 +103,12 @@ def deploy(branch_or_commit=DEFAULT_BRANCH):
 
 @task
 def manage(command):
-    require('tier', provided_by=(staging,production))
+    require('tier', provided_by=(staging, production))
     full_command = "/bin/bash -l -c 'source /var/www/env/bin/activate && python /var/www/project/manage.py {0}'".format(command)
     sudo(full_command, user="webproject")
 
 
 @task
 def restart_gunicorn():
-    require('tier', provided_by=(staging,production))
+    require('tier', provided_by=(staging, production))
     sudo('circusctl restart gunicorn')


### PR DESCRIPTION
Adds two tasks for switching between the different deployment tiers we
currently support: `staging` and `production`.  These tasks set values
on `env` according to that particular environment.  At this current
moment it's just the host to run the commands on, but it could be
anything.

This code now requires a tier to be set before running any tasks.  So
you can no longer run tasks with `fab -H <hostname> deploy`, you must
run, e.g., `fab staging deploy`.

Resolves #790.