### PR TITLE
Changed liability waiver to use Template.

### DIFF
--- a/brambling/models.py
+++ b/brambling/models.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from decimal import Decimal
 import itertools
 import json
+from string import Template
 
 from django.contrib.auth.models import (AbstractBaseUser, PermissionsMixin,
                                         BaseUserManager)
@@ -543,7 +544,11 @@ class Event(models.Model):
         })
 
     def get_liability_waiver(self):
-        return self.liability_waiver.format(event=self.name, organization=self.organization.name)
+        reformatted_template = (unicode(self.liability_waiver)
+                                .replace('{event}', '${event}')
+                                .replace('{organization}', '${organization}'))
+        templ = Template(reformatted_template)
+        return templ.safe_substitute(event=self.name, organization=self.organization.name)
 
     def get_permissions(self, person):
         if person.is_superuser:

--- a/brambling/models.py
+++ b/brambling/models.py
@@ -544,11 +544,9 @@ class Event(models.Model):
         })
 
     def get_liability_waiver(self):
-        reformatted_template = (unicode(self.liability_waiver)
-                                .replace('{event}', '${event}')
-                                .replace('{organization}', '${organization}'))
-        templ = Template(reformatted_template)
-        return templ.safe_substitute(event=self.name, organization=self.organization.name)
+        return (self.liability_waiver
+                .replace('{event}', self.name)
+                .replace('{organization}', self.organization.name))
 
     def get_permissions(self, person):
         if person.is_superuser:

--- a/brambling/models.py
+++ b/brambling/models.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from decimal import Decimal
 import itertools
 import json
-from string import Template
 
 from django.contrib.auth.models import (AbstractBaseUser, PermissionsMixin,
                                         BaseUserManager)

--- a/brambling/tests/functional/test_event_model.py
+++ b/brambling/tests/functional/test_event_model.py
@@ -6,6 +6,21 @@ from brambling.tests.factories import EventFactory, PersonFactory, OrderFactory
 
 
 class EventModelTestCase(TestCase):
+
+    def test_liability_waiver_subsitutes_org_name(self):
+        event = EventFactory()
+        self.assertIn(event.organization.name, event.get_liability_waiver())
+
+    def test_liability_waiver_subsitutes_event_name(self):
+        event = EventFactory()
+        event.liability_waiver = '{event} bears no responsibility for anything.'
+        self.assertIn(event.name, event.get_liability_waiver())
+
+    def test_liability_waiver_accepts_bracketed_words(self):
+        event = EventFactory()
+        event.liability_waiver = '{event} bears {no} responsibility for anything.'
+        self.assertIn('{no}', event.get_liability_waiver())
+
     def test_viewable_by__public_published__anon(self):
         event = EventFactory(is_published=True, privacy=Event.PUBLIC)
         person = AnonymousUser()


### PR DESCRIPTION
This seems better thant `string.format()` because (1) we are only using
basic substitutions and (2) we can make those substitutions more safely.

Fixed #807 

Currently, this is backwards compatible with the existing waivers in
the database that use `{bracketed}` syntax.  However, we have to convert
it to `${dollars bracket}` or just `$dollars` syntax to use the Template
class.  That's kind of a shim, so in the future we might want to:

1. Convert existing waivers in the DB to use `$event` and
`$organization`.
2. Change the help text for this field to reflect the above.

But that's not urgent.