### PR TITLE
Properly exempted Dwolla webhook from CSRF checks

### DIFF
--- a/brambling/tests/functional/test_webhooks.py
+++ b/brambling/tests/functional/test_webhooks.py
@@ -1,8 +1,9 @@
 import json
 
 from django.core.exceptions import SuspiciousOperation
+from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.test import TestCase, RequestFactory
+from django.test import Client, TestCase, RequestFactory
 import mock
 
 from brambling.models import Transaction
@@ -51,6 +52,11 @@ class DwollaWebhookTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.view = DwollaWebhookView.as_view()
+
+    def test_should_not_check_csrf_tokens(self):
+        csrf_client = Client(enforce_csrf_checks=True)
+        response = csrf_client.post(reverse('brambling_dwolla_webhook'))
+        self.assertNotEqual(response.status_code, 403)
 
     def test_bad_content_type(self):
         request = self.factory.post('/', content_type='text/xml', data='12345')

--- a/brambling/views/payment.py
+++ b/brambling/views/payment.py
@@ -94,6 +94,9 @@ class DwollaConnectView(View):
 
 class DwollaWebhookView(View):
     @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(DwollaWebhookView, self).dispatch(*args, **kwargs)
+
     def post(self, request, *args, **kwargs):
         if request.META['CONTENT_TYPE'] != "application/json":
             raise Http404("Incorrect content type")


### PR DESCRIPTION
The thing we were doing before was not appropriate for class-based
views.  I fixed it using the suggested method from the documentation and
put in a test for this behavior.
