### PR TITLE
Simplify dashboard

### DIFF
--- a/brambling/static/brambling/sass/modules/_event-listing.sass
+++ b/brambling/static/brambling/sass/modules/_event-listing.sass
@@ -1,6 +1,10 @@
 .event-listing-image
 	width: 100%
-	padding-top: (300 / 940) * 100%
+	// 300 / 940 is the height/width ratio of the banner image.
+	// We use this technique to scale the size of the element
+	// properly while still being responsive and avoiding
+	// layout shifting as images load.
+	padding-top: percentage(300 / 940)
 	background-image: $dancers-event-banner-url
 	background-size: cover
 	background-position: center

--- a/brambling/static/brambling/sass/modules/_event-listing.sass
+++ b/brambling/static/brambling/sass/modules/_event-listing.sass
@@ -1,6 +1,6 @@
 .event-listing-image
 	width: 100%
-	padding-top: 27%
+	padding-top: (300 / 940) * 100%
 	background-image: $dancers-event-banner-url
 	background-size: cover
 	background-position: center

--- a/brambling/static/brambling/sass/modules/_event-listing.sass
+++ b/brambling/static/brambling/sass/modules/_event-listing.sass
@@ -9,32 +9,12 @@
 	box-sizing: border-box
 	border-radius: $border-radius-base
 
-.datecard
-	position: absolute
-	top: 6px
-	left: 6px
-	text-align: center
-	width:  50px
-	height: 50px
-	border-radius: $border-radius-base
-	float: left
-	color: white
-	box-shadow: inset 0 0 0 1px rgba(0,0,0,.2)
-	background-color: rgba($yellow-dark,0.9)
-
-.datecard-month
-	margin: 5px 0 0
-	text-transform: uppercase
-	font-size: floor(($font-size-base * 1.25))
-	font-weight: $headings-font-weight-normal
-
-.datecard-day
-	margin: 0
-	line-height: 1em
-	font-size: floor(($font-size-base * 1.5))
-
 .event-listing
 	& > .relative-right
 		right: 6px
 	& > .relative-top
 		top: 6px
+
+	& > h3
+		margin-top: 10px
+		margin-bottom: 5px

--- a/brambling/static/brambling/sass/modules/_event-listing.sass
+++ b/brambling/static/brambling/sass/modules/_event-listing.sass
@@ -18,3 +18,7 @@
 	& > h3
 		margin-top: 10px
 		margin-bottom: 5px
+
+	& > h5
+		margin-top: 0
+		margin-bottom: 5px

--- a/brambling/static/brambling/sass/modules/_text.sass
+++ b/brambling/static/brambling/sass/modules/_text.sass
@@ -70,6 +70,10 @@ h1, .h1
 
 //// Buttons
 
+// There was a weird line height thing going on with buttons.
+.btn
+	line-height: 20px
+
 .btn-primary-light
 	+button-variant($btn-primary-color, $yellow-light, $btn-primary-border)
 

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -7,12 +7,6 @@
 <div class="margin-trailer-dbl event-listing relative">
 	<a href="{% url 'brambling_event_shop' event_slug=event.slug organization_slug=event.organization.slug %}" class="a-secret a-opacity">
 		<div class="event-listing-image"{% if banner_image %} style="background-image: url({{ banner_image }})"{% endif %}>
-			<div class="datecard">
-				<h5 class="datecard-month">{{ event.start_date|date:"M" }}</h5>
-				<p class="datecard-day">{{ event.start_date|date:"j" }}</p>
-			</div>
-
-
 		</div>
 	</a>
 	{% if is_registered %}
@@ -49,12 +43,12 @@
 			</small>
 		{% endif %}
 	</h3>
-	<p class="visible-inline-block margin-0">
+	<p class="margin-0">
 		<i class="fa fa-clock-o fa-fw"></i>
 		{% include "brambling/event/_when.html" %}
 	</p>
 	{% if event.city and event.state_or_province and event.country %}
-		<p class="visible-inline-block margin-leader-0 margin-trailer-half">
+		<p class="margin-leader-0 margin-trailer-half">
 			<i class="fa fa-map-marker fa-fw"></i>
 			{% include "brambling/event/_where.html" %}
 		</p>

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -4,8 +4,10 @@
 	{% adjust event.banner_image 'fill' width=940 height=300 as banner_image %}
 {% endif %}
 
+{% url 'brambling_event_shop' event_slug=event.slug organization_slug=event.organization.slug as event_url %}
+
 <div class="margin-trailer-dbl event-listing relative">
-	<a href="{% url 'brambling_event_shop' event_slug=event.slug organization_slug=event.organization.slug %}" class="a-secret a-opacity">
+	<a href="{{ event_url }}" class="a-secret a-opacity">
 		<div class="event-listing-image"{% if banner_image %} style="background-image: url({{ banner_image }})"{% endif %}>
 		</div>
 	</a>
@@ -35,7 +37,7 @@
 		</div>
 	{% endif %}
 	<h3>
-		{{ event.name }}
+		<a href="{{ event_url }}">{{ event.name }}</a>
 		{% if is_admin and not event.is_published %}
 			<small class='text-danger tipped' title="You can see this event because you're are an admin for it">
 				<i class='fa fa-fw fa-warning'></i>

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -11,10 +11,10 @@
 		<div class="event-listing-image"{% if banner_image %} style="background-image: url({{ banner_image }})"{% endif %}>
 		</div>
 	</a>
-	{% if is_registered %}
-		<div class="btn-group relative-right relative-top">
+	<div class="relative-right relative-top">
+		{% if is_registered %}
 			{% if event.order and event.order.has_cart %}
-				<a href="{{ event.get_absolute_url }}" class="margin-trailer-half btn btn-default tipped" title="Complete your registration now!" data-placement="bottom">
+				<a href="{{ event.get_absolute_url }}" class="btn btn-default tipped" title="Complete your registration now!" data-placement="bottom">
 					<i class="fa fa-exclamation-circle"></i> Cart expires in
 
 					{% td_to_dict event.order.cart_expire_time|td_timeuntil as time_left %}
@@ -34,8 +34,16 @@
 					<i class="fa fa-check"></i> Registered
 				</a>
 			{% endif %}
-		</div>
-	{% endif %}
+		{% endif %}
+		{% if is_admin %}
+			<a class="btn btn-default dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
+				<i class="fa fa-cog"></i>
+				Manage
+				<span class="caret"></span>
+			</a>
+			{% include "brambling/_event_manage_dropdown.html" with classes="dropdown-menu-right" %}
+		{% endif %}
+	</div>
 	<h3>
 		<a href="{{ event_url }}">{{ event.name }}</a>
 		{% if is_admin and not event.is_published %}

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -1,4 +1,4 @@
-{% load daguerre %}
+{% load daguerre zenaida %}
 
 {% if event.banner_image %}
 	{% adjust event.banner_image 'fill' width=940 height=300 as banner_image %}
@@ -15,15 +15,30 @@
 
 		</div>
 	</a>
-	{% if is_admin %}
-	<div class="btn-group relative-right relative-top">
-		<a class="btn btn-default dropdown-toggle tipped" title='Manage Event' type="button" id="manageEvent" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" data-container="body">
-			<i class="fa fa-cog"></i>
-			Manage
-			<span class="caret"></span>
-		</a>
-		{% include "brambling/_event_manage_dropdown.html" with classes="dropdown-menu-right" %}
-	</div>
+	{% if is_registered %}
+		<div class="btn-group relative-right relative-top">
+			{% if event.order and event.order.has_cart %}
+				<a href="{{ event.get_absolute_url }}" class="margin-trailer-half btn btn-default tipped" title="Complete your registration now!" data-placement="bottom">
+					<i class="fa fa-exclamation-circle"></i> Cart expires in
+
+					{% td_to_dict event.order.cart_expire_time|td_timeuntil as time_left %}
+
+					<strong data-countdown="timer">
+						{% if time_left.days %}<span data-countdown="days">{{ time_left.days }}</span> day{{ time_left.days|pluralize }}{% endif %}
+						{% if time_left.hours %}<span data-countdown="hours">{{ time_left.hours }}</span>:{% endif %}<span data-countdown="minutes">{% if time_left.minutes < 10 and time_left.hours %}0{% endif %}{{ time_left.minutes }}</span>:<span data-countdown="seconds">{% if time_left.seconds < 10 %}0{% endif %}{{ time_left.seconds }}</span>
+						{% if not time_left.hours %}min{% endif %}
+					</strong>
+				</a>
+			{% elif event.order and event.order.unconfirmed_checks %}
+				<a href="{{ event.get_absolute_url }}" class="margin-trailer-half btn btn-default tipped" title="Your payment by mail has not yet been received." data-placement="bottom">
+					<i class="fa fa-exclamation-circle"></i> Almost registered
+				</a>
+			{% else %}
+				<a href="{{ event.get_absolute_url }}" class="margin-trailer-half btn btn-success tipped" title="Modify your registration" data-placement="bottom">
+					<i class="fa fa-check"></i> Registered
+				</a>
+			{% endif %}
+		</div>
 	{% endif %}
 	<h3>
 		{{ event.name }}
@@ -45,50 +60,4 @@
 		</p>
 	{% endif %}
 	<h5 class="text-muted event-tags margin-0">{% for style in event.dance_styles.all %}<span class="list-comma">{{ style }}</span>{% endfor %}</h5>
-
-	<div class='form-group margin-leader-half'>
-			{% if is_registered %}
-				{% if event.order and event.order.has_cart %}
-					<a href="{{ event.get_absolute_url }}" class="margin-trailer-half btn btn-warning tipped" title="Complete your registration now!">
-						<i class="fa fa-exclamation-circle"></i> Almost Registered
-					</a>
-				{% elif event.order and event.order.unconfirmed_checks %}
-					<a href="{{ event.get_absolute_url }}" class="margin-trailer-half btn btn-warning tipped" title="Your payment by mail has not yet been received.">
-						<i class="fa fa-exclamation-circle"></i> Almost Registered
-					</a>
-				{% else %}
-					<a href="{{ event.get_absolute_url }}" class="margin-trailer-half btn btn-success tipped" title="Modify your registration">
-						<i class="fa fa-check"></i> Registered
-					</a>
-				{% endif %}
-			{% else %}
-				<a href="{{ event.get_absolute_url }}" class="margin-trailer-half btn btn-default">
-					<i class="fa fa-ticket"></i> Register <span class="hidden-xs hidden-sm hidden-md">for <strong>{{ event.name }}</strong>!</span>
-				</a>
-			{% endif %}
-		{% if event.website_url %}
-			<a target="_blank" href="{{ event.website_url }}" class="margin-trailer-half btn btn-default-dark">
-				<i class="fa fa-fw fa-globe"></i>
-				Website
-			</a>
-		{% endif %}
-		{% if event.facebook_url %}
-			<a target="_blank" href="{{ event.facebook_url }}" class="margin-trailer-half btn btn-default-dark">
-				<i class="fa fa-fw fa-facebook"></i>
-				Facebook
-			</a>
-		{% endif %}
-
-	</div>
-
-	{% if event.order and event.order.unconfirmed_checks %}
-		<div class='alert margin-trailer-md-0 alert-info'>
-			Note: Your passes are reserved, but the organizer has not yet received your payment by mail.
-			<br>If you believe this is in error, please contact the event organizer directly.
-		</div>
-	{% endif %}
-
-	{% if event.order and event.order.has_cart %}
-		{% include "brambling/event/order/_expiry_countdown.html" with expiry_time=event.order.cart_expire_time %}
-	{% endif %}
 </div>

--- a/brambling/templates/brambling/_event_list_item.html
+++ b/brambling/templates/brambling/_event_list_item.html
@@ -45,6 +45,11 @@
 			</small>
 		{% endif %}
 	</h3>
+	{% with styles=event.dance_styles.all %}
+		{% if styles %}
+			<h5 class="text-muted event-tags">{% for style in styles %}<span class="list-comma">{{ style }}</span>{% endfor %}</h5>
+		{% endif %}
+	{% endwith %}
 	<p class="margin-0">
 		<i class="fa fa-clock-o fa-fw"></i>
 		{% include "brambling/event/_when.html" %}
@@ -55,5 +60,4 @@
 			{% include "brambling/event/_where.html" %}
 		</p>
 	{% endif %}
-	<h5 class="text-muted event-tags margin-0">{% for style in event.dance_styles.all %}<span class="list-comma">{{ style }}</span>{% endfor %}</h5>
 </div>


### PR DESCRIPTION
An attempt at simplifying the dashboard. This would obviate #816. Changes are:

* Removes register/website/facebook/manage buttons from dashboard.
* Moves registration status onto event banner image (where manage button was)
* Makes banner image slightly taller so the whole thing actually displays
* Tightens margins in event metadata (name, date, location)
* Removes date card to cover up less of the banner image
* Removes verbose alerts below event image (since users can be expected to view a specific order to find those details)
* Linkifies event name.

<img width="469" alt="screen shot 2017-02-10 at 2 58 58 pm" src="https://cloud.githubusercontent.com/assets/299979/22847404/7f22db2c-efa1-11e6-8ce1-666b8afa0004.png">


See previous discussion in #834 