### PR TITLE
Fix 500 when Organizers save item notes

### DIFF
--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -1299,7 +1299,7 @@ class OrderDetailView(DetailView):
         self.transaction_refund_forms = [TransactionRefundForm(t)
                                          for t in self.order.transactions.all()]
         if can_edit_event:
-            forms = [self.payment_form, self.notes_form, self.transaction_refund_forms]
+            forms = [self.payment_form, self.notes_form] + self.transaction_refund_forms
         else:
             forms = [self.notes_form]
         return forms + self.attendee_forms


### PR DESCRIPTION
Closes #831. I've added reproduction instructions there.

OrderDetailView#get_forms erroneously produced a nested list of forms,
instead of appending a constructed list to another one. As it turns out,
this did not actually have much to do with notes themselves—this was
merely the avenue to discover the issue.