### PR TITLE
Corrected inclusion of attendees with transferred items in attendee table view

### DIFF
--- a/brambling/tests/functional/test_organizer_views.py
+++ b/brambling/tests/functional/test_organizer_views.py
@@ -11,6 +11,7 @@ from django.test import TestCase, RequestFactory
 
 from brambling.models import (
     Attendee,
+    BoughtItem,
     OrganizationMember,
     Transaction,
     Person,
@@ -236,6 +237,42 @@ class ModelTableViewTestCase(TestCase):
         self.assertEqual(response['content-disposition'], 'attachment; filename="export.csv"')
         content = list(response)
         self.assertIn('£200.00', content[1])
+
+
+class AttendeeFilterViewTest(TestCase):
+    def setUp(self):
+        self.event = EventFactory(collect_housing_data=True, currency='GBP')
+        self.order = OrderFactory(event=self.event)
+        self.transaction = TransactionFactory(
+            event=self.event,
+            order=self.order,
+        )
+        self.item = ItemFactory(event=self.event)
+        self.item_option = ItemOptionFactory(price=100, item=self.item)
+
+        self.order.add_to_cart(self.item_option)
+        self.order.mark_cart_paid(self.transaction)
+
+        self.attendee = AttendeeFactory(
+            order=self.order,
+            bought_items=self.order.bought_items.all(),
+        )
+
+        self.view = AttendeeFilterView()
+        self.view.event = self.event
+
+    def test_get_queryset__includes_bought(self):
+        self.assertEqual(
+            list(self.view.get_queryset()),
+            [self.attendee],
+        )
+
+    def test_get_queryset__includes_transferred(self):
+        self.order.bought_items.update(status=BoughtItem.TRANSFERRED)
+        self.assertEqual(
+            list(self.view.get_queryset()),
+            [self.attendee],
+        )
 
 
 class OrganizationRemoveMemberViewTestCase(TestCase):

--- a/brambling/tests/functional/test_organizer_views.py
+++ b/brambling/tests/functional/test_organizer_views.py
@@ -241,7 +241,7 @@ class ModelTableViewTestCase(TestCase):
 
 class AttendeeFilterViewTest(TestCase):
     def setUp(self):
-        self.event = EventFactory(collect_housing_data=True, currency='GBP')
+        self.event = EventFactory()
         self.order = OrderFactory(event=self.event)
         self.transaction = TransactionFactory(
             event=self.event,

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -1167,7 +1167,7 @@ class AttendeeFilterView(EventTableView):
         qs = super(AttendeeFilterView, self).get_queryset()
         return qs.filter(
             order__event=self.event,
-            bought_items__status=BoughtItem.BOUGHT,
+            bought_items__status__in=(BoughtItem.BOUGHT, BoughtItem.TRANSFERRED),
         ).distinct()
 
 


### PR DESCRIPTION
Attendees with only transferred items were not showing up in the attendee table view or the exported version of that view. This fixes that issue.