### PR TITLE
Made purchase_date annotation be added if purchase date ordering selected

### DIFF
--- a/brambling/tests/functional/test_attendee_table.py
+++ b/brambling/tests/functional/test_attendee_table.py
@@ -1,30 +1,48 @@
+import datetime
+
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
+from django.utils import timezone
 
-from brambling.utils.model_tables import AttendeeTable
+from brambling.utils.model_tables import (
+    AttendeeTable,
+    TABLE_COLUMN_FIELD,
+)
 from brambling.models import CustomFormEntry
 from brambling.tests.factories import (
-    TransactionFactory, EventFactory, OrderFactory, ItemFactory,
-    ItemOptionFactory, AttendeeFactory, EnvironmentalFactorFactory,
-    HousingRequestNightFactory, HousingCategoryFactory, CustomFormFactory,
-    CustomFormFieldFactory)
+    AttendeeFactory,
+    CustomFormFactory,
+    CustomFormFieldFactory,
+    EnvironmentalFactorFactory,
+    EventFactory,
+    HousingCategoryFactory,
+    HousingRequestNightFactory,
+    ItemFactory,
+    ItemOptionFactory,
+    OrderFactory,
+    TransactionFactory,
+)
+from brambling.utils.timezones import format_as_localtime
 
 
 class AttendeeTableTestCase(TestCase):
 
     def setUp(self):
-        event = EventFactory(collect_housing_data=True)
-        order = OrderFactory(event=event)
-        transaction = TransactionFactory(event=event, order=order)
-        item = ItemFactory(event=event)
-        item_option = ItemOptionFactory(price=100, item=item)
+        self.event = EventFactory(collect_housing_data=True)
+        self.item = ItemFactory(event=self.event)
+        self.item_option = ItemOptionFactory(price=100, item=self.item)
 
-        order.add_to_cart(item_option)
-        order.mark_cart_paid(transaction)
+        self.order = OrderFactory(event=self.event)
+        self.transaction = TransactionFactory(
+            event=self.event,
+            order=self.order,
+        )
+        self.order.add_to_cart(self.item_option)
+        self.order.mark_cart_paid(self.transaction)
 
         self.attendee = AttendeeFactory(
-            order=order,
-            bought_items=order.bought_items.all(),
+            order=self.order,
+            bought_items=self.order.bought_items.all(),
             housing_status='have',
             email='something@example.com',
             other_needs='99 mattresses',
@@ -42,9 +60,9 @@ class AttendeeTableTestCase(TestCase):
             EnvironmentalFactorFactory(name='Ontology'),
             EnvironmentalFactorFactory(name='Gnosticism'),
         ]
-        self.attendee.nights.add(HousingRequestNightFactory(date=event.start_date))
+        self.attendee.nights.add(HousingRequestNightFactory(date=self.event.start_date))
 
-        attendee_form = CustomFormFactory(event=event, form_type='attendee')
+        attendee_form = CustomFormFactory(event=self.event, form_type='attendee')
         f1 = CustomFormFieldFactory(form=attendee_form, name='favorite color')
         self.custom_key1 = f1.key
         entry1 = CustomFormEntry.objects.create(
@@ -54,7 +72,7 @@ class AttendeeTableTestCase(TestCase):
         entry1.set_value('ochre')
         entry1.save()
 
-        housing_form = CustomFormFactory(event=event, form_type='housing')
+        housing_form = CustomFormFactory(event=self.event, form_type='housing')
         f2 = CustomFormFieldFactory(form=housing_form, name='floor or bed')
         self.custom_key2 = f2.key
         entry2 = CustomFormEntry.objects.create(
@@ -63,8 +81,6 @@ class AttendeeTableTestCase(TestCase):
             form_field=f2)
         entry2.set_value('bed')
         entry2.save()
-
-        self.event = event
 
     def test_blank_housing_fields_if_attendee_does_not_need_housing(self):
         table = AttendeeTable(self.event)
@@ -105,3 +121,55 @@ class AttendeeTableTestCase(TestCase):
             self.assertNotEqual(row['person_prefer_if_needed'].value, '')
             self.assertNotEqual(row['person_avoid_if_needed'].value, '')
             self.assertNotEqual(row[self.custom_key2].value, '')
+
+    def test_purchase_date_field(self):
+        table = AttendeeTable(
+            event=self.event,
+            data={
+                TABLE_COLUMN_FIELD: ['pk', 'purchase_date'],
+            },
+        )
+        row = list(table)[0]
+        self.assertEqual(
+            row['purchase_date'].value,
+            format_as_localtime(
+                self.transaction.timestamp,
+                '%Y-%m-%d %H:%M',
+                self.event.timezone,
+            ),
+        )
+
+    def test_order_by_purchase_date(self):
+        """
+        If ordering by purchase date is selected, we should get that
+        ordering even if the field isn't selected.
+
+        """
+        order2 = OrderFactory(event=self.event)
+        transaction = TransactionFactory(
+            event=self.event,
+            order=order2,
+            timestamp=timezone.now() - datetime.timedelta(days=50)
+        )
+        order2.add_to_cart(self.item_option)
+        order2.mark_cart_paid(transaction)
+        attendee2 = AttendeeFactory(
+            order=order2,
+            bought_items=order2.bought_items.all(),
+            housing_status='have',
+            email='leia@example.com',
+            other_needs='99 mattresses',
+            person_avoid='Darth Vader',
+            person_prefer='Han Solo',
+        )
+
+        table = AttendeeTable(
+            event=self.event,
+            data={
+                'o': '-purchase_date',
+                TABLE_COLUMN_FIELD: ['pk', 'get_full_name'],
+            },
+        )
+        rows = list(table)
+        self.assertEqual(rows[0]['pk'].value, self.attendee.pk)
+        self.assertEqual(rows[1]['pk'].value, attendee2.pk)

--- a/brambling/tests/unit/test_model_tables.py
+++ b/brambling/tests/unit/test_model_tables.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from brambling.utils.model_tables import Row
 
 
-class PostalCodeTestCase(TestCase):
+class RowTestCase(TestCase):
     def test_iterable(self):
         data = [
             ('id', 5),

--- a/brambling/utils/model_tables.py
+++ b/brambling/utils/model_tables.py
@@ -461,10 +461,17 @@ class AttendeeTable(CustomDataTable):
                 queryset = queryset.prefetch_related('ef_cause')
             elif field == 'order_code':
                 queryset = queryset.select_related('order')
-            elif field == 'purchase_date':
-                queryset = queryset.annotate(
-                    purchase_date=Min('order__transactions__timestamp')
-                )
+
+        uses_purchase_date = (
+            'purchase_date' in fields or (
+                self.filter_form.is_valid() and
+                self.filter_form.cleaned_data.get('o') == '-purchase_date'
+            )
+        )
+        if uses_purchase_date:
+            queryset = queryset.annotate(
+                purchase_date=Min('order__transactions__timestamp')
+            )
         return queryset, use_distinct
 
     def _show_housing_data(self, attendee, form_entry):


### PR DESCRIPTION
`purchase_date` was an annotation field, but it was only being added if purchase_date was one of the visible fields. This change makes it so that the annotation is also added if the purchase date ordering is selected, even if the field is not visible. Resolved #877.