### PR TITLE
Switched stripe handling to use Stripe Elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 - pip install --no-deps -r requirements.txt
 - if [ $DATABASE_URL == 'postgres://postgres@localhost:5432/brambling_test' ]; then pip install --no-deps psycopg2==2.5.3;
   fi
-- pip install flake8
+- pip install flake8==3.3.0
 before_script:
 - if [ $DATABASE_URL == 'postgres://postgres@localhost:5432/brambling_test' ]; then psql -c 'drop database if exists brambling_test;'
   -U postgres; fi

--- a/brambling/templates/brambling/__base.html
+++ b/brambling/templates/brambling/__base.html
@@ -97,4 +97,6 @@
 			</script>
 		{% endif %}
 	{% endcompress %}
+
+	<script src="https://js.stripe.com/v3/"></script>
 {% endblock %}

--- a/brambling/templates/brambling/_stripe_form.html
+++ b/brambling/templates/brambling/_stripe_form.html
@@ -8,31 +8,8 @@
 	</div>
 {% endif %}
 
-
-<div class='row'>
-	<div class='col-xs-6'>
-		<div class='form-group'>
-			<label for='card-number'>Card number</label>
-			<input type='text' class='form-control' id='card-number' maxlength='16' placeholder='4242424242424242'{% if not api_type == 'test' and not request.is_secure %} disabled{% endif %}>
-		</div>
-		<div class='form-group'>
-			<label for='card-cvc'>CVC</label>
-			<input type='text' class='form-control' id='card-cvc' maxlength='4' placeholder='111'{% if not api_type == 'test' and not request.is_secure %} disabled{% endif %}>
-		</div>
-		<div class='form-group'>
-			<label for='card-cvc'>Expiration Date</label>
-			<div class='row'>
-				<div class='col-sm-6 margin-trailer'>
-					<input type='text' class='form-control' id='card-expiry-month' placeholder='MM' maxlength='2'{% if not api_type == 'test' and not request.is_secure %} disabled{% endif %}>
-				</div>
-				<div class='col-sm-6'>
-					<input type='text' class='form-control' id='card-expiry-year' placeholder='YY' maxlength='2'{% if not api_type == 'test' and not request.is_secure %} disabled{% endif %}>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class='col-xs-6'>
-		{% include 'brambling/_stripe_note.html' %}
-		<p class='text-muted'>A CVC code is an additional three or four digit number found on the back of your card.</p>
-	</div>
+<div class='form-group'>
+	<label for='card-element'>Credit or debit card</label>
+	<div id="card-element"></div>
 </div>
+{% include 'brambling/_stripe_note.html' %}

--- a/brambling/templates/brambling/_stripe_js.html
+++ b/brambling/templates/brambling/_stripe_js.html
@@ -1,38 +1,20 @@
-<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
 <script>
 	$(function(){
+		// External code must set stripe and card vars correctly.
 		$('#card-submit').on('click', function(e){
 			e.preventDefault();
 			$('.has-error').removeClass('has-error');
 			$('.help-block').remove();
 
-			Stripe.card.createToken({
-				number: $('#card-number').val(),
-				cvc: $('#card-cvc').val(),
-				exp_month: $('#card-expiry-month').val(),
-				exp_year: $('#card-expiry-year').val()
-			}, function(status, response) {
-				if (response.error) {
-					console.log(response.error);
-					var fieldId,
-						param=response.error.param;
-					if (param == 'number') {
-						fieldId = '#card-number';
-					} else if (param == 'exp_year') {
-						fieldId = '#card-expiry-year'
-					} else if (param == 'exp_month') {
-						fieldId = '#card-expiry-month'
-					} else if (param == 'cvc') {
-						fieldId = '#card-cvc'
-					}
-					if (fieldId) {
-						var group = $(fieldId).parent();
-						group.addClass('has-error');
-						group.append('<p class="help-block">' + response.error.message + '</p>');
-					}
+			stripe.createToken(card).then(function(result) {
+				if (result.error) {
+					console.log(result.error);
+					var group = $('#card-element').parent();
+					group.addClass('has-error');
+					group.append('<p class="help-block">' + result.error.message + '</p>');
 				} else {
 					var cardForm = $('#card-form');
-					cardForm.append("<input type='hidden' name='token' value='" + response['id'] + "'/>");
+					cardForm.append("<input type='hidden' name='token' value='" + result.token.id + "'/>");
 					cardForm.get(0).submit();
 				}
 			});

--- a/brambling/templates/brambling/_stripe_js.html
+++ b/brambling/templates/brambling/_stripe_js.html
@@ -8,7 +8,6 @@
 
 			stripe.createToken(card).then(function(result) {
 				if (result.error) {
-					console.log(result.error);
 					var group = $('#card-element').parent();
 					group.addClass('has-error');
 					group.append('<p class="help-block">' + result.error.message + '</p>');

--- a/brambling/templates/brambling/creditcard_add.html
+++ b/brambling/templates/brambling/creditcard_add.html
@@ -7,10 +7,26 @@
 {% block javascripts %}
 	{{ block.super }}
 	{% if api_type == TEST or request.is_secure %}
-		{% include "brambling/_stripe_js.html" %}
 		<script>
-			Stripe.setPublishableKey('{% if api_type == TEST %}{{ STRIPE_TEST_PUBLISHABLE_KEY }}{% else %}{{ STRIPE_PUBLISHABLE_KEY }}{% endif %}');
+			var publishableKey = '{% if api_type == TEST %}{{ STRIPE_TEST_PUBLISHABLE_KEY }}{% else %}{{ STRIPE_PUBLISHABLE_KEY }}{% endif %}';
+			var stripe = Stripe(publishableKey);
+			var elements = stripe.elements();
+			var card;
+			$(function() {
+				card = elements.create('card');
+				card.mount('#card-element');
+				card.addEventListener('change', function(event) {
+					$('.has-error').removeClass('has-error');
+					$('.help-block').remove();
+					if (event.error) {
+						var group = $('#card-element').parent();
+						group.addClass('has-error');
+						group.append('<p class="help-block">' + event.error.message + '</p>');
+					}
+				});
+			});
 		</script>
+		{% include "brambling/_stripe_js.html" %}
 	{% endif %}
 
 {% endblock %}

--- a/brambling/templates/brambling/event/order/summary.html
+++ b/brambling/templates/brambling/event/order/summary.html
@@ -12,20 +12,35 @@
 	</script>
 	{% include 'brambling/event/order/_use_discount_js.html' %}
 	{% if event.stripe_connected %}
-		{% include "brambling/_stripe_js.html" %}
 		<script>
+			var stripe, card;
 			function set_stripe_key() {
+				var publishableKey;
 				if ($('#id_save_card').prop('checked')) {
-					Stripe.setPublishableKey('{% if event.api_type == event.TEST %}{{ STRIPE_TEST_PUBLISHABLE_KEY }}{% else %}{{ STRIPE_PUBLISHABLE_KEY }}{% endif %}');
+					publishableKey = '{% if event.api_type == event.TEST %}{{ STRIPE_TEST_PUBLISHABLE_KEY }}{% else %}{{ STRIPE_PUBLISHABLE_KEY }}{% endif %}';
 				} else {
-					Stripe.setPublishableKey('{% if event.api_type == event.TEST %}{{ event.organization.stripe_test_publishable_key }}{% else %}{{ event.organization.stripe_publishable_key }}{% endif %}')
+					publishableKey = '{% if event.api_type == event.TEST %}{{ event.organization.stripe_test_publishable_key }}{% else %}{{ event.organization.stripe_publishable_key }}{% endif %}';
 				}
+				stripe = Stripe(publishableKey);
+				var elements = stripe.elements();
+				card = elements.create('card');
+				card.mount('#card-element');
+				card.addEventListener('change', function(event) {
+					$('.has-error').removeClass('has-error');
+					$('.help-block').remove();
+					if (event.error) {
+						var group = $('#card-element').parent();
+						group.addClass('has-error');
+						group.append('<p class="help-block">' + event.error.message + '</p>');
+					}
+				});
 			}
 			$('#id_save_card').on('change', function(e) {
 				set_stripe_key();
 			});
 			$(set_stripe_key);
 		</script>
+		{% include "brambling/_stripe_js.html" %}
 	{% endif %}
 	<script>
 		$(function() {


### PR DESCRIPTION
For PCI compliance and to avoid having to fill out annoying forms every year, we need to switch to using Stripe Elements. This only affects client-side code.

To test this PR:

- Add payment env vars to your dancerfly activate file from 1password
- Create a demo user (email: demo@dancerfly.com)
- Create a demo event (org slug: `demo`; event slug: `demo-event`)
- Create one item for the demo event.
- Connect the demo org to LW stripe account at `/demo/edit/payment/`

- Verify that setting of publishable key is the same, code-wise.
- Verify that, using test API, you are able to save a credit card or get errors from `/billing/`
- Verify that, using test API, you are able to check out for an event both with and without saving the card.