### PR TITLE
Fix newly uncovered flake8 error for bare `except:`

### DIFF
--- a/brambling/management/commands/send_daily_emails.py
+++ b/brambling/management/commands/send_daily_emails.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         for recipient in recipients:
             try:
                 self.send_digest(recipient)
-            except:
+            except Exception:
                 self.stderr.write("Digest send raised an error for {recipient} ({pk})".format(
                     recipient=recipient.get_full_name(),
                     pk=recipient.pk

--- a/brambling/models.py
+++ b/brambling/models.py
@@ -1962,7 +1962,7 @@ class CustomFormEntry(models.Model):
     def get_value(self):
         try:
             return json.loads(self.value)
-        except:
+        except Exception:
             return ''
 
 

--- a/brambling/views/orders.py
+++ b/brambling/views/orders.py
@@ -46,7 +46,7 @@ class RactiveShopView(TemplateView):
         clear_expired_carts(event)
         try:
             order = Order.objects.get(event=event, person=self.request.user)
-        except:
+        except Exception:
             order = None
 
         # TODO: This will never allow anonymous users to get past the

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -217,5 +217,5 @@ if ACCEPT_FEEDBACK:
 
 try:
     from .local_settings import *  # noqa: F403, F401
-except:
+except Exception:
     pass


### PR DESCRIPTION
Changes `except:` to `except Exception:`, a drop-in replacement that's
safer.

This also fixes flake8 on Circle CI.