### PR TITLE
Last zenaida removal blocker: Copied zenaida floppyforms templates into brambling templates folder

### DIFF
--- a/brambling/templates/floppyforms/checkbox_select.html
+++ b/brambling/templates/floppyforms/checkbox_select.html
@@ -1,0 +1,18 @@
+{% if inline %}
+	<div>
+		{% for group_name, choices in optgroups %}{% for choice in choices %}
+			<label class="checkbox-inline" for="{{ attrs.id }}_{{ forloop.counter }}">
+			  <input type="checkbox" id="{{ attrs.id }}_{{ forloop.counter }}" value="{{ choice.0 }}" name="{{ name }}"{% if required %} required{% endif %}{% if choice.0 in value %} checked{% endif %}> {{ choice.1 }}
+			</label>
+		{% endfor %}{% endfor %}
+	</div>
+{% else %}
+	{% for group_name, choices in optgroups %}{% for choice in choices %}
+	<div class="checkbox">
+	  <label for="{{ attrs.id }}_{{ forloop.counter }}">
+	    <input type="checkbox" id="{{ attrs.id }}_{{ forloop.counter }}" value="{{ choice.0 }}" name="{{ name }}"{% if required %} required{% endif %}{% if choice.0 in value %} checked{% endif %}>
+	    {{ choice.1 }}
+	  </label>
+	</div>
+	{% endfor %}{% endfor %}
+{% endif %}

--- a/brambling/templates/floppyforms/clearable_input.html
+++ b/brambling/templates/floppyforms/clearable_input.html
@@ -1,0 +1,10 @@
+{% load i18n daguerre %}{% if display_image %}<div><img src="{% adjust value 'fit' width=200 height=200 %}" /></div>{% endif %}
+<div>{% if value.url %}{% trans "Currently:" %} <a target="_blank" href="{{ value.url }}">{{ value }}</a>
+{% if not required %}
+<input type="checkbox" name="{{ checkbox_name }}" id="{{ checkbox_id }}">
+<label for="{{ checkbox_id }}">{% trans "Clear" %}</label>
+{% endif %}<br />
+{% trans "Change:" %}
+{% endif %}
+<input type="{{ type }}" name="{{ name }}"{% if required %} required{% endif %}{% include "floppyforms/attrs.html" %}>
+</div>

--- a/brambling/templates/floppyforms/errors.html
+++ b/brambling/templates/floppyforms/errors.html
@@ -1,0 +1,1 @@
+{% if errors %}{% for error in errors %}<span class="help-block">{{ error }}</span>{% endfor %}{% endif %}

--- a/brambling/templates/floppyforms/input.html
+++ b/brambling/templates/floppyforms/input.html
@@ -1,0 +1,19 @@
+{% load zenaida cache %}<input
+	{% if not type == "checkbox" %}class="form-control"{% endif %}
+	type="{{ type }}"
+	name="{{ name }}"
+	{% if datalist %} list="{{ attrs.id }}_list"{% endif %}
+	id="{{ attrs|pop_id }}"
+	{% if value %} value="{{ value }}"{% endif %}
+	{% if required %} required{% endif %}
+	{% if attrs %}{% cache 30 attrs attrs %}{% include "floppyforms/attrs.html" %}{% endcache %}{% endif %}
+	{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}
+	{% if autocomplete %} autocomplete="{{ autocomplete }}"{% endif %}
+>
+{% if datalist %}
+	<datalist id="{{ attrs.id }}_list">
+		{% for item in datalist %}
+			<option value="{{ item }}">
+		{% endfor %}
+	</datalist>
+{% endif %}

--- a/brambling/templates/floppyforms/layouts/bootstrap.html
+++ b/brambling/templates/floppyforms/layouts/bootstrap.html
@@ -1,0 +1,35 @@
+{% load floppyforms %}
+
+{% block forms %}
+	{% for form in forms %}
+		{% block errors %}
+			{% for error in form.non_field_errors %}
+				<div class="alert alert-danger fade in">
+					<a class="close" href="#" data-dismiss="alert">×</a>
+					{{ error }}
+				</div><!--- .alert.alert-error -->
+			{% endfor %}
+			{% for error in form|hidden_field_errors %}
+				<div class="alert alert-danger fade in">
+					<a class="close" href="#" data-dismiss="alert">×</a>
+					{{ error }}
+				</div><!--- .alert.alert-error -->
+			{% endfor %}
+		{% endblock errors %}
+		{% block rows %}
+			{% for field in form.visible_fields %}
+				{% if forloop.last %}
+					{% formconfig row with hidden_fields=form.hidden_fields %}
+				{% endif %}
+				{% block row %}
+					{% formrow field using "floppyforms/rows/bootstrap.html" %}
+				{% endblock %}
+			{% endfor %}
+			{% if not form.visible_fields %}
+				{% for field in form.hidden_fields %}
+					{% formfield field %}
+				{% endfor %}
+			{% endif %}
+		{% endblock %}
+	{% endfor %}
+{% endblock forms %}

--- a/brambling/templates/floppyforms/layouts/default.html
+++ b/brambling/templates/floppyforms/layouts/default.html
@@ -1,0 +1,1 @@
+{% extends "floppyforms/layouts/bootstrap.html" %}

--- a/brambling/templates/floppyforms/radio.html
+++ b/brambling/templates/floppyforms/radio.html
@@ -1,0 +1,18 @@
+{% if inline %}
+	<div>
+		{% for group_name, choices in optgroups %}{% for choice in choices %}
+			<label class="radio-inline" for="{{ attrs.id }}_{{ forloop.counter }}">
+			  <input type="radio" id="{{ attrs.id }}_{{ forloop.counter }}" value="{{ choice.0 }}" name="{{ name }}"{% if required %} required{% endif %}{% if choice.0 in value %} checked{% endif %}> {{ choice.1 }}
+			</label>
+		{% endfor %}{% endfor %}
+	</div>
+{% else %}
+	{% for group_name, choices in optgroups %}{% for choice in choices %}
+	<div class="radio">
+	  <label for="{{ attrs.id }}_{{ forloop.counter }}">
+	    <input type="radio" id="{{ attrs.id }}_{{ forloop.counter }}" value="{{ choice.0 }}" name="{{ name }}"{% if required %} required{% endif %}{% if choice.0 in value %} checked{% endif %}>
+	    {{ choice.1 }}
+	  </label>
+	</div>
+	{% endfor %}{% endfor %}
+{% endif %}

--- a/brambling/templates/floppyforms/rows/bootstrap.html
+++ b/brambling/templates/floppyforms/rows/bootstrap.html
@@ -1,0 +1,60 @@
+{% load floppyforms zenaida %}{% block row %}{% for field in fields %}
+<div class="{% block field_classes %}form-group{% if field.errors %} has-error{% endif %}{% endblock %}">
+	{% with classes=field.css_classes label=label|default:field.label help_text=help_text|default:field.help_text is_checkbox=field|is_checkbox %}
+		{% block field %}
+			{% if is_checkbox %}
+				{% block checkbox %}
+					<div class="checkbox">
+						<label for="{{ field|id }}">
+							{% if using %}{% formfield field using using %}{% else %}{% formfield field %}{% endif %} {{ label }} {% if field.field.required %} <span class="required">*</span>{% endif %}
+						</label>
+					</div>
+				{% endblock %}
+			{% else %}
+				{% block label %}
+					{% if field|id %}<label class="control-label" for="{{ field|id }}">{% endif %}
+					{{ label }}
+					{% if field.field.required %} <span class="required">*</span>{% endif %}
+					{% if field|id %}</label>{% endif %}
+				{% endblock %}
+				{% block widget %}
+					{% if not is_checkbox %}
+						{% if append or prepend %}
+							<div class='input-group'>
+								{% if prepend %}
+									<div class='input-group-addon'>
+										{{ prepend }}
+									</div>
+								{% endif %}
+						{% endif %}
+						{% if using %}{% formfield field using using %}{% else %}{% formfield field %}{% endif %}
+						{% if append or prepend %}
+								{% if append %}
+									<div class='input-group-addon'>
+										{{ append }}
+									</div>
+								{% endif %}
+							</div>
+						{% endif %}
+					{% endif %}
+				{% endblock %}
+			{% endif %}
+			{% block errors %}
+				{% if field.errors %}
+					{% include "floppyforms/errors.html" with errors=field.errors %}
+				{% endif %}
+			{% endblock %}
+			{% block help_text %}
+				{% if help_text %}
+					<p class="help-block">{{ help_text }}</p>
+				{% endif %}
+			{% endblock %}
+			{% block hidden_fields %}
+				{% for field in hidden_fields %}
+					{{ field.as_hidden }}
+				{% endfor %}
+			{% endblock %}
+		{% endblock field %}
+	{% endwith %}
+</div>{# /.form-group #}
+{% endfor %}{% endblock %}

--- a/brambling/templates/floppyforms/rows/confirm.html
+++ b/brambling/templates/floppyforms/rows/confirm.html
@@ -1,0 +1,21 @@
+{% extends 'floppyforms/rows/bootstrap.html' %}
+
+{% load floppyforms %}
+
+{% block field_classes %}form-group{% if field.errors or confirm.errors %} has-error{% endif %}{% endblock %}
+
+{% block widget %}
+	{% if not is_checkbox %}
+		<div class='input-group'>
+			{% formfield field %}
+			<span class='input-group-addon'>{% formfield confirm %}</span>
+		</div>
+	{% endif %}
+{% endblock %}
+
+{% block errors %}
+	{{ block.super }}
+	{% if confirm.errors %}
+		{% include "floppyforms/errors.html" with errors=confirm.errors %}
+	{% endif %}
+{% endblock %}

--- a/brambling/templates/floppyforms/rows/default.html
+++ b/brambling/templates/floppyforms/rows/default.html
@@ -1,0 +1,1 @@
+{% extends "floppyforms/rows/bootstrap.html" %}

--- a/brambling/templates/floppyforms/select.html
+++ b/brambling/templates/floppyforms/select.html
@@ -1,0 +1,16 @@
+{% load zenaida cache %}<select
+	class="chosen-select"
+	name="{{ name }}"
+	id="{{ attrs|pop_id }}"
+	{% if multiple %} multiple="multiple"{% endif %}
+	{% if required %} required{% endif %}
+	{% if attrs %}{% cache 30 attrs attrs %}{% include "floppyforms/attrs.html" %}{% endcache %}{% endif %}
+>
+	{% for group_name, group_choices in optgroups %}
+		{% if group_name %}<optgroup label="{{ group_name }}">{% endif %}
+			{% for option in group_choices %}
+				<option value="{{ option.0 }}"{% if option.0 in value %} selected="selected"{% endif %}>{{ option.1 }}</option>
+			{% endfor %}
+		{% if group_name %}</optgroup>{% endif %}
+	{% endfor %}
+</select>

--- a/brambling/templates/floppyforms/splitdatetime.html
+++ b/brambling/templates/floppyforms/splitdatetime.html
@@ -1,0 +1,7 @@
+<div class="row">
+	{% for widget in widgets %}
+		<div class="col-xs-6">
+			{{ widget }}
+		</div>
+	{% endfor %}
+</div>

--- a/brambling/templates/floppyforms/textarea.html
+++ b/brambling/templates/floppyforms/textarea.html
@@ -1,0 +1,8 @@
+{% load zenaida cache %}<textarea
+	class="form-control"
+	rows="3"
+	name="{{ name }}"
+	id="{{ attrs|pop_id }}"
+	{% if required %} required{% endif %}
+	{% if attrs %}{% cache 30 attrs attrs %}{% include "floppyforms/attrs.html" %}{% endcache %}{% endif %}
+>{% if value %}{{ value }}{% endif %}</textarea>


### PR DESCRIPTION
Resolved #937. Moved zenaida floppyforms templates into brambling templates folder. This is just a copy operation, and if there was an issue with it we wouldn't exactly notice atm since the two folders are redundant. You could verify that doing a copy of the relevant files again doesn't result in any new changes.